### PR TITLE
Application.start parameter update and subscribe argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Just to get people started:
 
 ``` elixir
 # make sure the application is started
-Tortoise.start(:normal, [])
+Tortoise.start(:temporary, [])
 
 # connect to the server and subscribe to foo/bar
 Tortoise.Supervisor.start_child(

--- a/lib/tortoise.ex
+++ b/lib/tortoise.ex
@@ -48,7 +48,7 @@ defmodule Tortoise do
     Inflight.track_sync(client_id, {:outgoing, subscribe}, 5000)
   end
 
-  def subscribe(client_id, topic) do
+  def subscribe(client_id, {_, n} = topic) when is_number(n) do
     subscribe(client_id, [topic])
   end
 

--- a/lib/tortoise.ex
+++ b/lib/tortoise.ex
@@ -10,7 +10,7 @@ defmodule Tortoise do
   @doc """
   Start the application supervisor
   """
-  def start(:normal, _args) do
+  def start(_type, _args) do
     # read configuration and start connections
     # start with client_id, and driver from config
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -302,7 +302,7 @@ defmodule Tortoise.TestTCPTunnel do
   end
 end
 
-{:ok, _} = Tortoise.start(:normal, [])
+{:ok, _} = Tortoise.start(:temporary, [])
 
 {:ok, _acceptor_pid} = Tortoise.TestTCPTunnel.start_link()
 

--- a/test/tortoise_test.exs
+++ b/test/tortoise_test.exs
@@ -3,6 +3,6 @@ defmodule TortoiseTest do
   doctest Tortoise
 
   test "greets the world" do
-    assert {:error, {:already_started, _pid}} = Tortoise.start(:normal, [])
+    assert {:error, {:already_started, _pid}} = Tortoise.start(:temporary, [])
   end
 end


### PR DESCRIPTION
This has two changes: 

1. Dialyzer caught the Application.start callback requiring `:normal` which it won't actually be sent. I updated the code to ignore the restart type field and where something was passed, I made it `:temporary` since that's the default.
2. Add a check on the argument type to `subscribe` to avoid a never ending recursion.