### PR TITLE
Retrieve a new pipe if the current socket is down during a publish

### DIFF
--- a/lib/tortoise.ex
+++ b/lib/tortoise.ex
@@ -2,6 +2,8 @@ defmodule Tortoise do
   use Application
 
   alias Tortoise.Connection.{Transmitter, Inflight}
+  alias Tortoise.Connection.Transmitter.Pipe
+  alias Tortoise.Package
 
   @moduledoc """
   Documentation for Tortoise.
@@ -26,10 +28,10 @@ defmodule Tortoise do
   @doc """
   Publish a message to the MQTT broker
   """
-  def publish(%{client_id: client_id} = pipe, topic, payload, opts \\ []) do
+  def publish(%Pipe{client_id: client_id} = pipe, topic, payload, opts \\ []) do
     qos = Keyword.get(opts, :qos, 0)
 
-    publish = %Tortoise.Package.Publish{
+    publish = %Package.Publish{
       topic: topic,
       qos: qos,
       payload: payload,


### PR DESCRIPTION
When a process holds a pipe containing a socket that is down it will enter a selective receive when it attempt to publish on this socket. The selective receive will listen for the new socket being send to its mailbox by the transmitter, and use this new pipe to send the message.

If the receive does not receive the new pipe within five seconds it will return an error-tuple. Perhaps the timeout should be a configuration setting on the pipe.

This pull request also implement tests for publishing using a pipe, and renewing a pipe when publishing to a pipe that has been closed.