### PR TITLE
Change the interface for the user defined driver behaviour

### DIFF
--- a/lib/tortoise/connection.ex
+++ b/lib/tortoise/connection.ex
@@ -140,7 +140,8 @@ defmodule Tortoise.Connection do
     {:ok, ref} = Controller.ping(state.connect.client_id)
 
     receive do
-      {Tortoise, {:ping_response, ^ref}} ->
+      {Tortoise, {:ping_response, ^ref, _round_trip_time}} ->
+        # Logger.info "Ping: #{round_trip_time} μs"
         state = reset_keep_alive(state)
         {:noreply, state}
     after

--- a/lib/tortoise/connection/controller.ex
+++ b/lib/tortoise/connection/controller.ex
@@ -144,7 +144,7 @@ defmodule Tortoise.Connection.Controller do
   end
 
   def handle_cast({:update_connection_status, new_status}, %State{} = state) do
-    case run_connection_callback(new_status, state) do
+    case run_connection_callback(new_status, %State{state | status: new_status}) do
       {:ok, state} ->
         {:noreply, state}
     end

--- a/lib/tortoise/connection/controller.ex
+++ b/lib/tortoise/connection/controller.ex
@@ -99,6 +99,11 @@ defmodule Tortoise.Connection.Controller do
     end
   end
 
+  def terminate(reason, state) do
+    _ignored = run_terminate_callback(reason, state)
+    :ok
+  end
+
   def handle_cast({:incoming, <<package::binary>>}, state) do
     package
     |> Package.decode()
@@ -284,6 +289,12 @@ defmodule Tortoise.Connection.Controller do
         updated_driver = %{state.driver | state: initial_state}
         {:ok, %__MODULE__{state | driver: updated_driver}}
     end
+  end
+
+  defp run_terminate_callback(reason, state) do
+    args = [reason, state.driver.state]
+
+    apply(state.driver.module, :terminate, args)
   end
 
   defp run_publish_callback(%Publish{} = publish, state) do

--- a/lib/tortoise/connection/controller.ex
+++ b/lib/tortoise/connection/controller.ex
@@ -24,7 +24,11 @@ defmodule Tortoise.Connection.Controller do
 
   use GenServer
 
-  defstruct client_id: nil, ping: :queue.new(), driver: %Driver{}
+  @enforce_keys [:client_id, :driver]
+  defstruct client_id: nil,
+            ping: :queue.new(),
+            driver: %Driver{module: Tortoise.Driver.Logger, initial_args: []}
+
   alias __MODULE__, as: State
 
   # Client API

--- a/lib/tortoise/connection/controller.ex
+++ b/lib/tortoise/connection/controller.ex
@@ -232,7 +232,7 @@ defmodule Tortoise.Connection.Controller do
     topic_list = String.split(publish.topic, "/")
     args = [topic_list, publish.payload, state.driver.state]
 
-    case apply(state.driver.module, :on_publish, args) do
+    case apply(state.driver.module, :handle_message, args) do
       {:ok, updated_driver_state} ->
         updated_driver = %{state.driver | state: updated_driver_state}
         {:ok, %__MODULE__{state | driver: updated_driver}}

--- a/lib/tortoise/connection/controller.ex
+++ b/lib/tortoise/connection/controller.ex
@@ -314,7 +314,8 @@ defmodule Tortoise.Connection.Controller do
        ) do
     # @todo, figure out what to do when a qos is return than the one requested
     updated_driver_state =
-      Enum.reduce(subacks, state.driver.state, fn {:ok, topic_filter}, acc ->
+      Enum.reduce(subacks, state.driver.state, fn {:ok, {topic_filter, _qos}}, acc ->
+        # notice, we ignore the reported qos here for now
         args = [:up, topic_filter, acc]
 
         case apply(state.driver.module, :subscription, args) do

--- a/lib/tortoise/connection/inflight/track.ex
+++ b/lib/tortoise/connection/inflight/track.ex
@@ -209,7 +209,7 @@ defmodule Tortoise.Connection.Inflight.Track do
            ]
          } = track
        ) do
-    %State{track | result: {:unsubscribed, topics}}
+    %State{track | result: topics}
   end
 
   defp finalize(

--- a/lib/tortoise/driver.ex
+++ b/lib/tortoise/driver.ex
@@ -25,4 +25,7 @@ defmodule Tortoise.Driver do
   @callback subscription(status(), binary(), term()) :: {:ok, term()}
 
   @callback handle_message(topic(), binary(), term()) :: {:ok, term()}
+
+  @callback terminate(reason, state :: term) :: term
+            when reason: :normal | :shutdown | {:shutdown, term}
 end

--- a/lib/tortoise/driver.ex
+++ b/lib/tortoise/driver.ex
@@ -23,6 +23,4 @@ defmodule Tortoise.Driver do
   @callback subscription(status(), binary(), term()) :: {:ok, term()}
 
   @callback handle_message(topic(), binary(), term()) :: {:ok, term()}
-
-  @callback disconnect(term()) :: :ok
 end

--- a/lib/tortoise/driver.ex
+++ b/lib/tortoise/driver.ex
@@ -20,6 +20,8 @@ defmodule Tortoise.Driver do
 
   @callback init(term()) :: {:ok, term()}
 
+  @callback connection(status(), term()) :: {:ok, term()}
+
   @callback subscription(status(), binary(), term()) :: {:ok, term()}
 
   @callback handle_message(topic(), binary(), term()) :: {:ok, term()}

--- a/lib/tortoise/driver.ex
+++ b/lib/tortoise/driver.ex
@@ -18,13 +18,17 @@ defmodule Tortoise.Driver do
   @type topic() :: [binary()]
   @type status() :: :up | :down
 
-  @callback init(term()) :: {:ok, term()}
+  @callback init(args :: term) :: {:ok, state}
+            when state: any
 
-  @callback connection(status(), term()) :: {:ok, term()}
+  @callback connection(status(), state :: term) :: {:ok, new_state}
+            when new_state: term
 
-  @callback subscription(status(), binary(), term()) :: {:ok, term()}
+  @callback subscription(status(), binary(), state :: term) :: {:ok, new_state}
+            when new_state: term
 
-  @callback handle_message(topic(), binary(), term()) :: {:ok, term()}
+  @callback handle_message(topic(), binary(), state :: term) :: {:ok, new_state}
+            when new_state: term
 
   @callback terminate(reason, state :: term) :: term
             when reason: :normal | :shutdown | {:shutdown, term}

--- a/lib/tortoise/driver.ex
+++ b/lib/tortoise/driver.ex
@@ -20,7 +20,5 @@ defmodule Tortoise.Driver do
 
   @callback on_publish(topic(), binary(), term()) :: {:ok, term()}
 
-  @callback ping_response(integer(), term()) :: {:ok, term()}
-
   @callback disconnect(term()) :: :ok
 end

--- a/lib/tortoise/driver.ex
+++ b/lib/tortoise/driver.ex
@@ -18,7 +18,7 @@ defmodule Tortoise.Driver do
 
   @callback init(term()) :: {:ok, term()}
 
-  @callback on_publish(topic(), binary(), term()) :: {:ok, term()}
+  @callback handle_message(topic(), binary(), term()) :: {:ok, term()}
 
   @callback disconnect(term()) :: :ok
 end

--- a/lib/tortoise/driver.ex
+++ b/lib/tortoise/driver.ex
@@ -1,6 +1,7 @@
 defmodule Tortoise.Driver do
   @moduledoc false
 
+  @enforce_keys [:module, :initial_args]
   defstruct module: nil, state: nil, initial_args: []
 
   @doc """

--- a/lib/tortoise/driver.ex
+++ b/lib/tortoise/driver.ex
@@ -15,8 +15,11 @@ defmodule Tortoise.Driver do
   def new(%__MODULE__{} = driver), do: driver
 
   @type topic() :: [binary()]
+  @type status() :: :up | :down
 
   @callback init(term()) :: {:ok, term()}
+
+  @callback subscription(status(), binary(), term()) :: {:ok, term()}
 
   @callback handle_message(topic(), binary(), term()) :: {:ok, term()}
 

--- a/lib/tortoise/driver/default.ex
+++ b/lib/tortoise/driver/default.ex
@@ -1,0 +1,24 @@
+defmodule Tortoise.Driver.Default do
+  @moduledoc false
+
+  @behaviour Tortoise.Driver
+
+  defstruct []
+  alias __MODULE__, as: State
+
+  def init(_opts) do
+    {:ok, %State{}}
+  end
+
+  def connection(_status, state) do
+    {:ok, state}
+  end
+
+  def subscription(_status, _topic, state) do
+    {:ok, state}
+  end
+
+  def handle_message(_topic, _publish, state) do
+    {:ok, state}
+  end
+end

--- a/lib/tortoise/driver/default.ex
+++ b/lib/tortoise/driver/default.ex
@@ -21,4 +21,8 @@ defmodule Tortoise.Driver.Default do
   def handle_message(_topic, _publish, state) do
     {:ok, state}
   end
+
+  def terminate(_reason, _state) do
+    :ok
+  end
 end

--- a/lib/tortoise/driver/logger.ex
+++ b/lib/tortoise/driver/logger.ex
@@ -9,7 +9,7 @@ defmodule Tortoise.Driver.Logger do
     {:ok, []}
   end
 
-  def on_publish(topic, publish, state) do
+  def handle_message(topic, publish, state) do
     Logger.info("#{Enum.join(topic, "/")} #{inspect(publish)}")
     {:ok, state}
   end

--- a/lib/tortoise/driver/logger.ex
+++ b/lib/tortoise/driver/logger.ex
@@ -23,9 +23,4 @@ defmodule Tortoise.Driver.Logger do
     Logger.info("#{Enum.join(topic, "/")} #{inspect(publish)}")
     {:ok, state}
   end
-
-  def disconnect(_state) do
-    Logger.info("Disconnected")
-    :ok
-  end
 end

--- a/lib/tortoise/driver/logger.ex
+++ b/lib/tortoise/driver/logger.ex
@@ -9,6 +9,16 @@ defmodule Tortoise.Driver.Logger do
     {:ok, []}
   end
 
+  def subscription(:up, {topic, qos}, state) do
+    Logger.info("Subscribed to #{topic} with QoS #{qos}")
+    {:ok, state}
+  end
+
+  def subscription(:down, topic, state) do
+    Logger.info("Unsubscribed from #{topic}")
+    {:ok, state}
+  end
+
   def handle_message(topic, publish, state) do
     Logger.info("#{Enum.join(topic, "/")} #{inspect(publish)}")
     {:ok, state}

--- a/lib/tortoise/driver/logger.ex
+++ b/lib/tortoise/driver/logger.ex
@@ -3,10 +3,23 @@ defmodule Tortoise.Driver.Logger do
 
   require Logger
 
+  defstruct []
+  alias __MODULE__, as: State
+
   @behaviour Tortoise.Driver
 
   def init(_opts) do
-    {:ok, []}
+    {:ok, %State{}}
+  end
+
+  def connection(:up, state) do
+    Logger.info("Connection has been established")
+    {:ok, state}
+  end
+
+  def connection(:down, state) do
+    Logger.warn("Connection has been dropped")
+    {:ok, state}
   end
 
   def subscription(:up, {topic, qos}, state) do

--- a/lib/tortoise/driver/logger.ex
+++ b/lib/tortoise/driver/logger.ex
@@ -38,7 +38,7 @@ defmodule Tortoise.Driver.Logger do
   end
 
   def terminate(reason, _state) do
-    Logger.warn("Client has been terminated with reason: #{inspect reason}")
+    Logger.warn("Client has been terminated with reason: #{inspect(reason)}")
     :ok
   end
 end

--- a/lib/tortoise/driver/logger.ex
+++ b/lib/tortoise/driver/logger.ex
@@ -36,4 +36,9 @@ defmodule Tortoise.Driver.Logger do
     Logger.info("#{Enum.join(topic, "/")} #{inspect(publish)}")
     {:ok, state}
   end
+
+  def terminate(reason, _state) do
+    Logger.warn("Client has been terminated with reason: #{inspect reason}")
+    :ok
+  end
 end

--- a/lib/tortoise/driver/logger.ex
+++ b/lib/tortoise/driver/logger.ex
@@ -14,11 +14,6 @@ defmodule Tortoise.Driver.Logger do
     {:ok, state}
   end
 
-  def ping_response(round_trip_time, state) do
-    Logger.info("Ping completed in #{round_trip_time}μs")
-    {:ok, state}
-  end
-
   def disconnect(_state) do
     Logger.info("Disconnected")
     :ok

--- a/test/tortoise/connection/controller_test.exs
+++ b/test/tortoise/connection/controller_test.exs
@@ -18,7 +18,7 @@ defmodule Tortoise.Connection.ControllerTest do
       {:ok, %__MODULE__{pid: caller, client_id: client_id}}
     end
 
-    def on_publish(topic, message, %__MODULE__{} = state) do
+    def handle_message(topic, message, %__MODULE__{} = state) do
       new_state = %__MODULE__{
         state
         | publish_count: state.publish_count + 1,

--- a/test/tortoise/connection/controller_test.exs
+++ b/test/tortoise/connection/controller_test.exs
@@ -8,7 +8,11 @@ defmodule Tortoise.Connection.ControllerTest do
   defmodule TestDriver do
     @behaviour Tortoise.Driver
 
-    defstruct pid: nil, client_id: nil, publish_count: 0, received: [], subscriptions: []
+    defstruct pid: nil,
+              client_id: nil,
+              publish_count: 0,
+              received: [],
+              subscriptions: []
 
     def init([client_id, caller]) when is_pid(caller) do
       # We pass in the caller `pid` and keep it in the state so we can
@@ -16,6 +20,14 @@ defmodule Tortoise.Connection.ControllerTest do
       # possible to make assertions on the changes in the driver
       # callback module
       {:ok, %__MODULE__{pid: caller, client_id: client_id}}
+    end
+
+    def connection(:up, state) do
+      {:ok, state}
+    end
+
+    def connection(:down, state) do
+      {:ok, state}
     end
 
     def subscription(:up, {topic_filter, _qos}, state) do

--- a/test/tortoise/connection/controller_test.exs
+++ b/test/tortoise/connection/controller_test.exs
@@ -29,10 +29,6 @@ defmodule Tortoise.Connection.ControllerTest do
       {:ok, new_state}
     end
 
-    def ping_response(_round_trip_time, state) do
-      {:ok, state}
-    end
-
     def disconnect(_state) do
       :ok
     end
@@ -94,7 +90,7 @@ defmodule Tortoise.Connection.ControllerTest do
       assert %Package.Pingreq{} = Package.decode(package)
       # the server will respond with an pingresp (ping response)
       Controller.handle_incoming(context.client_id, %Package.Pingresp{})
-      assert_receive {Tortoise, {:ping_response, ^ping_ref}}
+      assert_receive {Tortoise, {:ping_response, ^ping_ref, _ping_time}}
     end
 
     test "receive a ping request", context do
@@ -113,9 +109,9 @@ defmodule Tortoise.Connection.ControllerTest do
 
       # the controller should respond to ping requests in FIFO order
       Controller.handle_incoming(context.client_id, %Package.Pingresp{})
-      assert_receive {Tortoise, {:ping_response, ^first_ping_ref}}
+      assert_receive {Tortoise, {:ping_response, ^first_ping_ref, _}}
       Controller.handle_incoming(context.client_id, %Package.Pingresp{})
-      assert_receive {Tortoise, {:ping_response, ^second_ping_ref}}
+      assert_receive {Tortoise, {:ping_response, ^second_ping_ref, _}}
     end
   end
 

--- a/test/tortoise/connection/controller_test.exs
+++ b/test/tortoise/connection/controller_test.exs
@@ -59,6 +59,11 @@ defmodule Tortoise.Connection.ControllerTest do
       send(state.pid, new_state)
       {:ok, new_state}
     end
+
+    def terminate(reason, state) do
+      send(state.pid, {:terminating, reason})
+      :ok
+    end
   end
 
   # Setup ==============================================================
@@ -104,6 +109,7 @@ defmodule Tortoise.Connection.ControllerTest do
     assert Process.alive?(pid)
     assert :ok = Controller.stop(context.client_id)
     refute Process.alive?(pid)
+    assert_receive {:terminating, :normal}
   end
 
   describe "Connection callback" do

--- a/test/tortoise/connection/controller_test.exs
+++ b/test/tortoise/connection/controller_test.exs
@@ -29,7 +29,7 @@ defmodule Tortoise.Connection.ControllerTest do
       {:ok, new_state}
     end
 
-    def subscription(:up, {topic_filter, _qos}, state) do
+    def subscription(:up, topic_filter, state) do
       new_state = %__MODULE__{
         state
         | subscriptions: [topic_filter | state.subscriptions]

--- a/test/tortoise/connection/controller_test.exs
+++ b/test/tortoise/connection/controller_test.exs
@@ -48,10 +48,6 @@ defmodule Tortoise.Connection.ControllerTest do
       send(state.pid, new_state)
       {:ok, new_state}
     end
-
-    def disconnect(_state) do
-      :ok
-    end
   end
 
   # Setup ==============================================================

--- a/test/tortoise/connection_test.exs
+++ b/test/tortoise/connection_test.exs
@@ -41,7 +41,7 @@ defmodule Tortoise.ConnectionTest do
       opts = [
         client_id: client_id,
         server: {:tcp, ip, port},
-        driver: {Tortoise.Driver.Logger, []}
+        driver: {Tortoise.Driver.Default, []}
       ]
 
       assert {:ok, _pid} = Connection.start_link(opts)
@@ -68,7 +68,7 @@ defmodule Tortoise.ConnectionTest do
       opts = [
         client_id: client_id,
         server: {:tcp, ip, port},
-        driver: {Tortoise.Driver.Logger, []}
+        driver: {Tortoise.Driver.Default, []}
       ]
 
       assert {:ok, _pid} = Connection.start_link(opts)
@@ -98,7 +98,7 @@ defmodule Tortoise.ConnectionTest do
       opts = [
         client_id: client_id,
         server: {:tcp, ip, port},
-        driver: {Tortoise.Driver.Logger, []}
+        driver: {Tortoise.Driver.Default, []}
       ]
 
       assert {:error, {:connection_failed, :unacceptable_protocol_version}} ==
@@ -121,7 +121,7 @@ defmodule Tortoise.ConnectionTest do
       opts = [
         client_id: client_id,
         server: {:tcp, ip, port},
-        driver: {Tortoise.Driver.Logger, []}
+        driver: {Tortoise.Driver.Default, []}
       ]
 
       assert {:error, {:connection_failed, :identifier_rejected}} == Connection.start_link(opts)
@@ -142,7 +142,7 @@ defmodule Tortoise.ConnectionTest do
       opts = [
         client_id: client_id,
         server: {:tcp, ip, port},
-        driver: {Tortoise.Driver.Logger, []}
+        driver: {Tortoise.Driver.Default, []}
       ]
 
       assert {:error, {:connection_failed, :server_unavailable}} == Connection.start_link(opts)
@@ -163,7 +163,7 @@ defmodule Tortoise.ConnectionTest do
       opts = [
         client_id: client_id,
         server: {:tcp, ip, port},
-        driver: {Tortoise.Driver.Logger, []}
+        driver: {Tortoise.Driver.Default, []}
       ]
 
       assert {:error, {:connection_failed, :bad_user_name_or_password}} ==
@@ -186,7 +186,7 @@ defmodule Tortoise.ConnectionTest do
       opts = [
         client_id: client_id,
         server: {:tcp, ip, port},
-        driver: {Tortoise.Driver.Logger, []}
+        driver: {Tortoise.Driver.Default, []}
       ]
 
       assert {:error, {:connection_failed, :not_authorized}} == Connection.start_link(opts)


### PR DESCRIPTION
The "Driver" allow the user to specify what should happen when certain events happen on the connection. The plan is to implement callbacks for events such as a connection state change, a subscription state change, and when the client receive a message on a topic filter it subscribe to. Callbacks such as init and terminating should also be available to the user.

When applied it should solve #4 