### PR TITLE
Implement `ping_sync/2` on the Controller

### DIFF
--- a/lib/tortoise/connection.ex
+++ b/lib/tortoise/connection.ex
@@ -140,15 +140,13 @@ defmodule Tortoise.Connection do
   end
 
   def handle_info(:ping, %State{} = state) do
-    {:ok, ref} = Controller.ping(state.connect.client_id)
-
-    receive do
-      {Tortoise, {:ping_response, ^ref, _round_trip_time}} ->
-        # Logger.info "Ping: #{round_trip_time} μs"
+    case Controller.ping_sync(state.connect.client_id, 5000) do
+      {:ok, round_trip_time} ->
+        Logger.debug("Ping: #{round_trip_time} μs")
         state = reset_keep_alive(state)
         {:noreply, state}
-    after
-      5000 ->
+
+      {:stop, :timeout} ->
         {:stop, :ping_timeout, state}
     end
   end

--- a/lib/tortoise/connection/controller.ex
+++ b/lib/tortoise/connection/controller.ex
@@ -65,6 +65,18 @@ defmodule Tortoise.Connection.Controller do
     {:ok, ref}
   end
 
+  def ping_sync(client_id, timeout \\ :infinity) do
+    {:ok, ref} = ping(client_id)
+
+    receive do
+      {Tortoise, {:ping_response, ^ref, round_trip_time}} ->
+        {:ok, round_trip_time}
+    after
+      timeout ->
+        {:error, :timeout}
+    end
+  end
+
   def handle_incoming(client_id, package) do
     GenServer.cast(via_name(client_id), {:incoming, package})
   end


### PR DESCRIPTION
Also switched to using the new `ping_sync/2` on the `Tortoise.Connection.Controller` instead of the one implemented directly on the `Tortoise.Connection`-module.

If we change the implementation of the ping await the Controller will get the change as well. Also this provides a `ping_sync/2` which can be used by the user to ping the server without having to pull out the response from the mailbox themselves.

The first argument is the `client_id` the second one is the timeout given in milliseconds.

When applied fixes #16 