### PR TITLE
Fix output sometimes written during test runs

### DIFF
--- a/lib/tortoise/connection.ex
+++ b/lib/tortoise/connection.ex
@@ -85,6 +85,11 @@ defmodule Tortoise.Connection do
     end
   end
 
+  def handle_info({:tcp_closed, _socket}, state) do
+    Logger.error("Socket closed before we handed it to the receiver")
+    {:stop, :connection_refused, state}
+  end
+
   def handle_info({:DOWN, ref, :port, port, :normal}, %State{monitor_ref: {port, ref}} = state) do
     connect = %Connect{state.connect | clean_session: false}
     :ok = Controller.update_connection_status(connect.client_id, :down)

--- a/lib/tortoise/connection.ex
+++ b/lib/tortoise/connection.ex
@@ -90,7 +90,8 @@ defmodule Tortoise.Connection do
     {:stop, :connection_refused, state}
   end
 
-  def handle_info({:DOWN, ref, :port, port, :normal}, %State{monitor_ref: {port, ref}} = state) do
+  def handle_info({:DOWN, ref, :port, port, reason}, %State{monitor_ref: {port, ref}} = state)
+      when reason in [:normal, :noproc] do
     connect = %Connect{state.connect | clean_session: false}
     :ok = Controller.update_connection_status(connect.client_id, :down)
 

--- a/lib/tortoise/connection/receiver.ex
+++ b/lib/tortoise/connection/receiver.ex
@@ -74,8 +74,14 @@ defmodule Tortoise.Connection.Receiver do
 
   # activate network socket for incoming traffic
   def handle_event(:internal, :activate_socket, _state_name, data) do
-    :ok = :inet.setopts(data.socket, active: :once)
-    :keep_state_and_data
+    case :inet.setopts(data.socket, active: :once) do
+      :ok ->
+        :keep_state_and_data
+
+      {:error, :einval} ->
+        # @todo consider if there could be a we buffer should drain at this point
+        {:next_state, :disconnected, data}
+    end
   end
 
   # consume buffer

--- a/lib/tortoise/connection/receiver.ex
+++ b/lib/tortoise/connection/receiver.ex
@@ -43,7 +43,7 @@ defmodule Tortoise.Connection.Receiver do
       :ok ->
         :ok
 
-      {:error, :closed} ->
+      {:error, reason} when reason in [:closed, :einval] ->
         # todo, this is an edge case, figure out what to do here
         :ok
     end


### PR DESCRIPTION
Sometimes the tests can get the application into weird states, and this causes weird output to appear in the test reports—not that they are failing any of the tests…things would just be much cleaner if it didn't output that stuff.

I will investigate the causes and take care of the reasons processes crashes. When this is applied it should fix #14 