### PR TITLE
Revamp the user facing publish interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,11 +38,6 @@ Tortoise.Supervisor.start_child(
 Tortoise.publish("my_client_id", "foo/bar", "Hello from the World of Tomorrow !", qos: 0)
 ```
 
-The "pipe" concept should get a better description, it is basically a
-struct that holds a socket we can put MQTT Publish messages into, and
-they will get shot directly on the server.
-
-
 ## Installation
 
 It is not available on hex yet, but it will be soon!

--- a/README.md
+++ b/README.md
@@ -27,24 +27,15 @@ I would love to get some feedback and help building this thing.
 Just to get people started:
 
 ``` elixir
-# connect to the server and subscribe to foo/bar
+# connect to the server and subscribe to foo/bar with QoS 0
 Tortoise.Supervisor.start_child(
     client_id: "my_client_id",
     driver: {Tortoise.Driver.Logger, []},
     server: {:tcp, 'localhost', 1883},
     subscriptions: [{"foo/bar", 0}])
 
-# Open a pipe we can post stuff into...
-
-# ...while the word subscribe might be confusing it is meant to mean
-# "subscribe to a connection on the transmitter"; the subscribing
-# process will get a new pipe when the connection is reestablished, for
-# what ever reason. The pipe will be in the mailbox of the subscribing
-# process.
-{:ok, pipe} = Tortoise.Connection.Transmitter.subscribe_await("my_client_id");
-
 # publish a message on the broker
-Tortoise.publish(pipe, "foo/bar", "Hello from the World of Tomorrow !", qos: 0)
+Tortoise.publish("my_client_id", "foo/bar", "Hello from the World of Tomorrow !", qos: 0)
 ```
 
 The "pipe" concept should get a better description, it is basically a

--- a/lib/tortoise/connection.ex
+++ b/lib/tortoise/connection.ex
@@ -68,8 +68,7 @@ defmodule Tortoise.Connection do
 
     case publish do
       %Package.Publish{qos: 0} ->
-        {:ok, pipe} = Transmitter.publish(pipe, publish)
-        pipe
+        Pipe.publish(pipe, publish)
 
       %Package.Publish{qos: qos} when qos in [1, 2] ->
         Inflight.track(pipe, {:outgoing, publish})

--- a/lib/tortoise/connection.ex
+++ b/lib/tortoise/connection.ex
@@ -8,7 +8,7 @@ defmodule Tortoise.Connection do
   alias __MODULE__, as: State
 
   alias Tortoise.Connection
-  alias Tortoise.Connection.{Inflight, Controller, Receiver}
+  alias Tortoise.Connection.{Inflight, Controller, Receiver, Transmitter}
   alias Tortoise.Package
   alias Tortoise.Package.{Connect, Connack}
 
@@ -52,6 +52,45 @@ defmodule Tortoise.Connection do
       start: {__MODULE__, :start_link, [opts]},
       type: :worker
     }
+  end
+
+  # Public interface
+  def publish(client_id, topic, payload \\ nil, opts \\ []) do
+    qos = Keyword.get(opts, :qos, 0)
+
+    publish = %Package.Publish{
+      topic: topic,
+      qos: qos,
+      payload: payload,
+      retain: Keyword.get(opts, :retain, false)
+    }
+
+    case publish do
+      %Package.Publish{qos: 0} ->
+        Transmitter.cast(client_id, publish)
+
+      %Package.Publish{qos: qos} when qos in [1, 2] ->
+        Inflight.track(client_id, {:outgoing, publish})
+    end
+  end
+
+  def publish_sync(client_id, topic, payload \\ nil, opts \\ [], timeout \\ :infinity) do
+    qos = Keyword.get(opts, :qos, 0)
+
+    publish = %Package.Publish{
+      topic: topic,
+      qos: qos,
+      payload: payload,
+      retain: Keyword.get(opts, :retain, false)
+    }
+
+    case publish do
+      %Package.Publish{qos: 0} ->
+        Transmitter.cast(client_id, publish)
+
+      %Package.Publish{qos: qos} when qos in [1, 2] ->
+        Inflight.track_sync(client_id, {:outgoing, publish}, timeout)
+    end
   end
 
   # Callbacks

--- a/lib/tortoise/connection.ex
+++ b/lib/tortoise/connection.ex
@@ -7,7 +7,7 @@ defmodule Tortoise.Connection do
   defstruct [:socket, :monitor_ref, :connect, :server, :session, :subscriptions, :keep_alive]
   alias __MODULE__, as: State
 
-  alias Tortoise.{Connection, Package, Pipe}
+  alias Tortoise.{Connection, Package}
   alias Tortoise.Connection.{Inflight, Controller, Receiver, Transmitter}
   alias Tortoise.Package.{Connect, Connack}
 

--- a/lib/tortoise/connection.ex
+++ b/lib/tortoise/connection.ex
@@ -54,28 +54,7 @@ defmodule Tortoise.Connection do
   end
 
   # Public interface
-  def publish(client_id, topic, payload \\ nil, opts \\ [])
-
-  def publish(%Pipe{} = pipe, topic, payload, opts) do
-    qos = Keyword.get(opts, :qos, 0)
-
-    publish = %Package.Publish{
-      topic: topic,
-      qos: qos,
-      payload: payload,
-      retain: Keyword.get(opts, :retain, false)
-    }
-
-    case publish do
-      %Package.Publish{qos: 0} ->
-        Pipe.publish(pipe, publish)
-
-      %Package.Publish{qos: qos} when qos in [1, 2] ->
-        Inflight.track(pipe, {:outgoing, publish})
-    end
-  end
-
-  def publish(client_id, topic, payload, opts) do
+  def publish(client_id, topic, payload \\ nil, opts \\ []) do
     qos = Keyword.get(opts, :qos, 0)
 
     publish = %Package.Publish{

--- a/lib/tortoise/connection.ex
+++ b/lib/tortoise/connection.ex
@@ -7,9 +7,8 @@ defmodule Tortoise.Connection do
   defstruct [:socket, :monitor_ref, :connect, :server, :session, :subscriptions, :keep_alive]
   alias __MODULE__, as: State
 
-  alias Tortoise.Connection
+  alias Tortoise.{Connection, Package, Pipe}
   alias Tortoise.Connection.{Inflight, Controller, Receiver, Transmitter}
-  alias Tortoise.Package
   alias Tortoise.Package.{Connect, Connack}
 
   def start_link(opts) do
@@ -57,7 +56,7 @@ defmodule Tortoise.Connection do
   # Public interface
   def publish(client_id, topic, payload \\ nil, opts \\ [])
 
-  def publish(%Transmitter.Pipe{} = pipe, topic, payload, opts) do
+  def publish(%Pipe{} = pipe, topic, payload, opts) do
     qos = Keyword.get(opts, :qos, 0)
 
     publish = %Package.Publish{

--- a/lib/tortoise/connection/controller.ex
+++ b/lib/tortoise/connection/controller.ex
@@ -90,7 +90,7 @@ defmodule Tortoise.Connection.Controller do
         caller: {pid, ref},
         result: :ok
       }) do
-    send(pid, {Tortoise, {{client_id, ref}, :ok}})
+    send(pid, {{Tortoise, client_id}, ref, :ok})
     :ok
   end
 

--- a/lib/tortoise/connection/inflight.ex
+++ b/lib/tortoise/connection/inflight.ex
@@ -3,7 +3,7 @@ defmodule Tortoise.Connection.Inflight do
   A process keeping track of the messages in flight
   """
 
-  alias Tortoise.Package
+  alias Tortoise.{Package, Pipe}
   alias Tortoise.Connection.{Controller, Transmitter}
   alias Tortoise.Connection.Inflight.Track
 
@@ -38,7 +38,7 @@ defmodule Tortoise.Connection.Inflight do
     :ok = GenServer.cast(via_name(client_id), {:incoming, publish})
   end
 
-  def track(%Transmitter.Pipe{client_id: client_id} = pipe, {:outgoing, package}) do
+  def track(%Pipe{client_id: client_id} = pipe, {:outgoing, package}) do
     caller = {_, ref} = {self(), make_ref()}
 
     case package do
@@ -52,7 +52,7 @@ defmodule Tortoise.Connection.Inflight do
         :ok = GenServer.cast(via_name(client_id), {:outgoing, caller, package})
     end
 
-    %Transmitter.Pipe{pipe | pending: [ref | pipe.pending]}
+    %Pipe{pipe | pending: [ref | pipe.pending]}
   end
 
   def track(client_id, {:outgoing, package}) do

--- a/lib/tortoise/connection/inflight.ex
+++ b/lib/tortoise/connection/inflight.ex
@@ -61,7 +61,7 @@ defmodule Tortoise.Connection.Inflight do
     {:ok, ref} = track(client_id, command)
 
     receive do
-      {Tortoise, {{^client_id, ^ref}, result}} ->
+      {{Tortoise, ^client_id}, ^ref, result} ->
         result
     after
       timeout -> {:error, :timeout}

--- a/lib/tortoise/connection/inflight.ex
+++ b/lib/tortoise/connection/inflight.ex
@@ -88,6 +88,11 @@ defmodule Tortoise.Connection.Inflight do
     :ok = GenServer.cast(via_name(client_id), {:update, event})
   end
 
+  @doc false
+  def list_tracking(client_id) do
+    GenServer.call(via_name(client_id), :list_tracking)
+  end
+
   # Server callbacks
   def init(state) do
     {:ok, state}
@@ -121,6 +126,10 @@ defmodule Tortoise.Connection.Inflight do
       {:ok, state} ->
         {:noreply, state}
     end
+  end
+
+  def handle_call(:list_tracking, _from, state) do
+    {:reply, state.pending, state}
   end
 
   # helpers

--- a/lib/tortoise/connection/inflight.ex
+++ b/lib/tortoise/connection/inflight.ex
@@ -88,11 +88,6 @@ defmodule Tortoise.Connection.Inflight do
     :ok = GenServer.cast(via_name(client_id), {:update, event})
   end
 
-  @doc false
-  def list_tracking(client_id) do
-    GenServer.call(via_name(client_id), :list_tracking)
-  end
-
   # Server callbacks
   def init(state) do
     {:ok, state}
@@ -126,10 +121,6 @@ defmodule Tortoise.Connection.Inflight do
       {:ok, state} ->
         {:noreply, state}
     end
-  end
-
-  def handle_call(:list_tracking, _from, state) do
-    {:reply, state.pending, state}
   end
 
   # helpers

--- a/lib/tortoise/connection/transmitter.ex
+++ b/lib/tortoise/connection/transmitter.ex
@@ -4,16 +4,17 @@ defmodule Tortoise.Connection.Transmitter do
   use GenStateMachine
 
   alias Tortoise.Package
-  alias Tortoise.Pipe
 
-  defstruct client_id: nil, subscribers: %{}
+  @enforce_keys [:client_id]
+  defstruct client_id: nil, subscribers: %{}, once: []
+  alias __MODULE__, as: State
 
   @type client_id :: pid() | term()
 
   # Client API
   def start_link(opts) do
     client_id = Keyword.fetch!(opts, :client_id)
-    data = %__MODULE__{client_id: client_id}
+    data = %State{client_id: client_id}
     GenStateMachine.start_link(__MODULE__, data, name: via_name(client_id))
   end
 
@@ -45,22 +46,6 @@ defmodule Tortoise.Connection.Transmitter do
     GenStateMachine.call(via_name(client_id), {:handle_socket, socket})
   end
 
-  def subscribe(client_id) do
-    GenStateMachine.call(via_name(client_id), :subscribe)
-  end
-
-  def subscribe_await(client_id, timeout \\ :infinity) do
-    :ok = subscribe(client_id)
-
-    receive do
-      {{Tortoise, ^client_id}, :transmitter, pipe} ->
-        {:ok, pipe}
-    after
-      timeout ->
-        {:error, :timeout}
-    end
-  end
-
   def unsubscribe(client_id) do
     GenStateMachine.cast(via_name(client_id), {:unsubscribe, self()})
   end
@@ -71,21 +56,21 @@ defmodule Tortoise.Connection.Transmitter do
     GenStateMachine.call(via_name(client_id), :get_subscribers)
   end
 
-  def publish(%Pipe{module: :tcp} = pipe, %Package.Publish{} = data) do
-    client_id = pipe.client_id
-    publish = Tortoise.Package.encode(data)
+  def get_socket(client_id, opts \\ [timeout: :infinity]) do
+    active = Keyword.get(opts, :active, false)
+    timeout = Keyword.get(opts, :timeout, :infinity)
 
-    case :gen_tcp.send(pipe.socket, publish) do
-      :ok ->
-        {:ok, pipe}
+    case GenStateMachine.call(via_name(client_id), {:get_socket, active}) do
+      {:ok, socket} ->
+        {:ok, socket}
 
-      {:error, :closed} ->
+      :pending ->
         receive do
-          {{Tortoise, ^client_id}, :transmitter, pipe} ->
-            publish(pipe, data)
+          {{Tortoise, ^client_id}, :socket, socket} ->
+            {:ok, socket}
         after
-          5000 ->
-            {:error, :closed}
+          timeout ->
+            {:error, :timeout}
         end
     end
   end
@@ -100,27 +85,7 @@ defmodule Tortoise.Connection.Transmitter do
     {:ok, :disconnected, data, []}
   end
 
-  def handle_event({:call, from}, {:handle_socket, socket}, _, data) do
-    new_state = {:connected, socket}
-
-    next_actions = [
-      {:reply, from, :ok},
-      {:next_event, :internal, :broadcast_connection_to_subscribers}
-    ]
-
-    {:next_state, new_state, data, next_actions}
-  end
-
-  def handle_event(:internal, :broadcast_connection_to_subscribers, {:connected, socket}, data) do
-    pipe = %Pipe{socket: socket, client_id: data.client_id}
-
-    for {subscriber, _} <- data.subscribers do
-      send_transmitter_to_subscriber(subscriber, pipe)
-    end
-
-    :keep_state_and_data
-  end
-
+  # Putting data on the wire
   def handle_event(:cast, {:transmit, package}, {:connected, socket}, data) do
     case :gen_tcp.send(socket, package) do
       :ok ->
@@ -138,45 +103,98 @@ defmodule Tortoise.Connection.Transmitter do
     {:keep_state_and_data, :postpone}
   end
 
-  def handle_event({:call, {pid, _} = from}, :subscribe, _, %__MODULE__{} = data) do
-    monitor_ref = Process.monitor(pid)
-    next_actions = [{:reply, from, :ok}, {:next_event, :internal, {:send_socket, pid}}]
-    updated_subscribers = Map.put(data.subscribers, pid, monitor_ref)
-    updated_data = %__MODULE__{data | subscribers: updated_subscribers}
-    {:keep_state, updated_data, next_actions}
+  # receiving sockets and dispatching to processes holding pipes
+  # configured as "active"
+  def handle_event({:call, from}, {:handle_socket, socket}, _, data) do
+    new_state = {:connected, socket}
+
+    next_actions = [
+      {:reply, from, :ok},
+      {:next_event, :internal, :handle_once},
+      {:next_event, :internal, :broadcast_socket}
+    ]
+
+    {:next_state, new_state, data, next_actions}
   end
 
-  def handle_event(:internal, {:send_socket, subscriber}, {:connected, socket}, data) do
-    pipe = %Pipe{socket: socket, client_id: data.client_id}
-    send_transmitter_to_subscriber(subscriber, pipe)
+  def handle_event(:internal, :broadcast_socket, {:connected, socket}, data) do
+    for {subscriber, _monitor_ref} <- data.subscribers do
+      send(subscriber, {{Tortoise, data.client_id}, :socket, socket})
+    end
+
     :keep_state_and_data
   end
 
-  def handle_event(:internal, {:send_socket, _subscriber}, :disconnected, _data) do
-    # a connection will get broadcast when we get online
+  # handle the socket to passive pipes
+  def handle_event(:internal, :handle_once, {:connected, _socket}, %State{once: []}) do
     :keep_state_and_data
   end
 
-  def handle_event(:cast, {:unsubscribe, pid}, _, %__MODULE__{} = data) do
+  def handle_event(:internal, :handle_once, {:connected, socket}, %State{} = data) do
+    for pid <- data.once do
+      send(pid, {{Tortoise, data.client_id}, :socket, socket})
+    end
+
+    {:keep_state, %State{data | once: []}}
+  end
+
+  # socket subscriptions
+  def handle_event(:internal, {:add_subscriber, client_pid}, _, %State{} = data) do
+    monitor_ref = Process.monitor(client_pid)
+    updated_subscribers = Map.put(data.subscribers, client_pid, monitor_ref)
+    {:keep_state, %State{data | subscribers: updated_subscribers}}
+  end
+
+  def handle_event(:cast, {:unsubscribe, pid}, _, %State{} = data) do
     {monitor_ref, updated_subscribers} = Map.pop(data.subscribers, pid)
-    updated_data = %__MODULE__{data | subscribers: updated_subscribers}
+    updated_data = %State{data | subscribers: updated_subscribers}
     true = Process.demonitor(monitor_ref)
     {:keep_state, updated_data}
   end
 
-  def handle_event({:call, from}, :get_subscribers, _, %__MODULE__{} = data) do
+  def handle_event(:info, {:DOWN, ref, :process, pid, _}, _, data) do
+    {^ref, updated_subscribers} = Map.pop(data.subscribers, pid)
+    updated_data = %State{data | subscribers: updated_subscribers}
+    {:keep_state, updated_data}
+  end
+
+  def handle_event({:call, from}, :get_subscribers, _, %State{} = data) do
     subscribers = Map.keys(data.subscribers)
     next_action = {:reply, from, subscribers}
     {:keep_state_and_data, next_action}
   end
 
-  def handle_event(:info, {:DOWN, ref, :process, pid, _}, _, data) do
-    {^ref, updated_subscribers} = Map.pop(data.subscribers, pid)
-    updated_data = %{data | subscribers: updated_subscribers}
-    {:keep_state, updated_data}
+  # requesting sockets
+  def handle_event({:call, {pid, _} = from}, {:get_socket, true}, {:connected, socket}, %State{}) do
+    next_actions = [
+      {:next_event, :internal, {:add_subscriber, pid}},
+      {:reply, from, {:ok, socket}}
+    ]
+
+    {:keep_state_and_data, next_actions}
   end
 
-  defp send_transmitter_to_subscriber(subscriber_pid, %Pipe{client_id: client_id} = transmitter) do
-    send(subscriber_pid, {{Tortoise, client_id}, :transmitter, transmitter})
+  def handle_event({:call, from}, {:get_socket, false}, {:connected, socket}, %State{}) do
+    next_action = {:reply, from, {:ok, socket}}
+    {:keep_state_and_data, next_action}
+  end
+
+  def handle_event({:call, {pid, _ref} = from}, {:get_socket, true}, :disconnected, %State{}) do
+    next_actions = [
+      {:next_event, :internal, {:add_subscriber, pid}},
+      {:reply, from, :pending}
+    ]
+
+    {:keep_state_and_data, next_actions}
+  end
+
+  def handle_event(
+        {:call, {pid, _ref} = from},
+        {:get_socket, false},
+        :disconnected,
+        %State{} = data
+      ) do
+    next_action = {:reply, from, :pending}
+    {:keep_state, %State{data | once: [pid | data.once]}, next_action}
   end
 end

--- a/lib/tortoise/connection/transmitter.ex
+++ b/lib/tortoise/connection/transmitter.ex
@@ -4,7 +4,6 @@ defmodule Tortoise.Connection.Transmitter do
   use GenStateMachine
 
   alias Tortoise.Package
-  alias Tortoise.Connection.Inflight
   alias Tortoise.Connection.Transmitter.Pipe
 
   defstruct client_id: nil, subscribers: %{}

--- a/lib/tortoise/connection/transmitter.ex
+++ b/lib/tortoise/connection/transmitter.ex
@@ -4,6 +4,7 @@ defmodule Tortoise.Connection.Transmitter do
   use GenStateMachine
 
   alias Tortoise.Package
+  alias Tortoise.Connection.Inflight
   alias Tortoise.Connection.Transmitter.Pipe
 
   defstruct client_id: nil, subscribers: %{}

--- a/lib/tortoise/connection/transmitter.ex
+++ b/lib/tortoise/connection/transmitter.ex
@@ -4,7 +4,7 @@ defmodule Tortoise.Connection.Transmitter do
   use GenStateMachine
 
   alias Tortoise.Package
-  alias Tortoise.Connection.Transmitter.Pipe
+  alias Tortoise.Pipe
 
   defstruct client_id: nil, subscribers: %{}
 

--- a/lib/tortoise/connection/transmitter/pipe.ex
+++ b/lib/tortoise/connection/transmitter/pipe.ex
@@ -20,7 +20,7 @@ defmodule Tortoise.Connection.Transmitter.Pipe do
   alias Tortoise.Connection.Transmitter
 
   @enforce_keys [:client_id, :socket]
-  defstruct [:client_id, :socket, module: :tcp]
+  defstruct [:client_id, :socket, module: :tcp, pending: []]
 
   defimpl Collectable do
     def into(pipe) do

--- a/lib/tortoise/pipe.ex
+++ b/lib/tortoise/pipe.ex
@@ -4,14 +4,15 @@ defmodule Tortoise.Pipe do
   type that can be given to a process. It contains amongst other
   things a socket.
 
-  A process can obtain a transmitter pipe by subscribing to a
-  Transmitter, which will broadcast a updated transmitter pipe when a
-  new socket is created for the transmitter.
+  A process can obtain a transmitter pipe by issuing a `pipe =
+  Tortoise.Pipe.new(client_id)` request, which will result in a pipe
+  in passive mode, meaning it will hold a socket it can publish
+  messages into, but might fail, in which case it will attempt to get
+  another socket from the transmitter. This all happens behind the
+  scenes, it is important though that the returned pipe is used in
+  future pipe requests, so publishing on a pipe should look like this:
 
-  The pipe is a one way construction. It is only possible to pour data
-  into a pipe, and it will only result in a message control package
-  with quality of service zero. If a higher quality of service is
-  needed the message should go through the in flight tracker process.
+    pipe = Tortoise.Pipe.publish(pipe, "foo/bar", "bonjour !")
 
   @todo, document this stuff, and document it better.
   """

--- a/lib/tortoise/pipe.ex
+++ b/lib/tortoise/pipe.ex
@@ -1,4 +1,4 @@
-defmodule Tortoise.Connection.Transmitter.Pipe do
+defmodule Tortoise.Pipe do
   @moduledoc """
   The transmitter "pipe", for lack of a better word, is an opaque data
   type that can be given to a process. It contains amongst other

--- a/test/tortoise/connection/controller_test.exs
+++ b/test/tortoise/connection/controller_test.exs
@@ -216,7 +216,7 @@ defmodule Tortoise.Connection.ControllerTest do
       # the server will send back an ack message
       Controller.handle_incoming(client_id, %Package.Puback{identifier: 1})
       # the caller should get a message in its mailbox
-      assert_receive {Tortoise, {{^client_id, ^ref}, :ok}}
+      assert_receive {{Tortoise, ^client_id}, ^ref, :ok}
     end
 
     test "outgoing publish with qos 1 sync call", context do
@@ -277,7 +277,7 @@ defmodule Tortoise.Connection.ControllerTest do
       # receive pubcomp
       Controller.handle_incoming(client_id, %Package.Pubcomp{identifier: 1})
       # the caller should get a message in its mailbox
-      assert_receive {Tortoise, {{^client_id, ^ref}, :ok}}
+      assert_receive {{Tortoise, ^client_id}, ^ref, :ok}
     end
   end
 

--- a/test/tortoise/connection/transmitter_test.exs
+++ b/test/tortoise/connection/transmitter_test.exs
@@ -49,7 +49,7 @@ defmodule Tortoise.Connection.TransmitterTest do
       assert Transmitter.subscribers(client_id) == [self()]
       # when we get a connection the subscribers should get a socket
       _context = run_setup(context, :setup_connection)
-      assert_receive {Tortoise, {:transmitter, %Pipe{socket: socket}}}
+      assert_receive {{Tortoise, ^client_id}, :transmitter, %Pipe{socket: socket}}
       assert is_port(socket)
     end
 
@@ -59,7 +59,7 @@ defmodule Tortoise.Connection.TransmitterTest do
       assert :ok = Transmitter.subscribe(client_id)
       assert Transmitter.subscribers(client_id) == [self()]
       # The Transmitter should send the socket to the subscriber
-      assert_receive {Tortoise, {:transmitter, %Pipe{socket: socket}}}
+      assert_receive {{Tortoise, ^client_id}, :transmitter, %Pipe{socket: socket}}
       assert is_port(socket)
     end
 
@@ -105,7 +105,7 @@ defmodule Tortoise.Connection.TransmitterTest do
       # first we create the subscription
       assert :ok = Transmitter.subscribe(client_id)
       context = run_setup(context, :setup_connection)
-      assert_receive {Tortoise, {:transmitter, _socket}}
+      assert_receive {{Tortoise, ^client_id}, :transmitter, _socket}
       # attempt to unsubscribe from the transmitter
       :ok = Transmitter.unsubscribe(client_id)
       assert Transmitter.subscribers(client_id) == []
@@ -114,7 +114,7 @@ defmodule Tortoise.Connection.TransmitterTest do
       # subscribed at this point, so we should not receive the
       # broadcast.
       _context = run_setup(context, :setup_connection)
-      refute_receive {Tortoise, {:transmitter, _socket}}
+      refute_receive {{Tortoise, ^client_id}, :transmitter, _socket}
     end
   end
 
@@ -124,7 +124,7 @@ defmodule Tortoise.Connection.TransmitterTest do
     test "publishing on a pipe", context do
       client_id = context.client_id
       assert :ok = Transmitter.subscribe(client_id)
-      assert_receive {Tortoise, {:transmitter, pipe}}
+      assert_receive {{Tortoise, ^client_id}, :transmitter, pipe}
       publish = %Package.Publish{topic: "foo"}
 
       Transmitter.publish(pipe, publish)

--- a/test/tortoise/pipe_test.exs
+++ b/test/tortoise/pipe_test.exs
@@ -1,0 +1,10 @@
+defmodule Tortoise.PipeTest do
+  use ExUnit.Case
+  doctest Tortoise.Pipe
+
+  alias Tortoise.Pipe
+
+  test "generate a pipe", context do
+    assert %Pipe{client_id: context.test, socket: "hello"}
+  end
+end

--- a/test/tortoise/pipe_test.exs
+++ b/test/tortoise/pipe_test.exs
@@ -2,9 +2,115 @@ defmodule Tortoise.PipeTest do
   use ExUnit.Case
   doctest Tortoise.Pipe
 
-  alias Tortoise.Pipe
+  alias Tortoise.{Pipe, Package}
+  alias Tortoise.Connection.Transmitter
 
-  test "generate a pipe", context do
-    assert %Pipe{client_id: context.test, socket: "hello"}
+  def setup_transmitter(context) do
+    opts = [client_id: context.test]
+    {:ok, pid} = Transmitter.start_link(opts)
+    {:ok, %{transmitter_pid: pid}}
   end
+
+  def setup_connection(context) do
+    {:ok, client_socket, server_socket} = Tortoise.TestTCPTunnel.new()
+    :ok = Transmitter.handle_socket(context.test, client_socket)
+    {:ok, %{client: client_socket, server: server_socket}}
+  end
+
+  # update the context during a test run
+  def run_setup(context, setup) when is_atom(setup) do
+    context_update =
+      case apply(__MODULE__, setup, [context]) do
+        {:ok, update} -> update
+        [{_, _} | _] = update -> update
+        %{} = update -> update
+      end
+
+    Enum.into(context_update, context)
+  end
+
+  describe "new/2" do
+    setup [:setup_transmitter]
+
+    test "generate a pipe when transmitter is online", context do
+      context = run_setup(context, :setup_connection)
+      assert %Pipe{} = Pipe.new(context.test)
+    end
+
+    test "generate a pipe when transmitter is offline", context do
+      parent = self()
+      client_id = context.test
+
+      spawn_link(fn ->
+        result = Pipe.new(client_id)
+        send(parent, {:result, result})
+      end)
+
+      :timer.sleep(200)
+      _ = run_setup(context, :setup_connection)
+      assert_receive {:result, %Pipe{client_id: ^client_id}}
+    end
+  end
+
+  describe "publish/4" do
+    setup [:setup_transmitter, :setup_connection]
+
+    test "publish a message", context do
+      pipe = Pipe.new(context.test)
+      topic = "foo/bar"
+      payload = "my message"
+
+      assert %Pipe{} = Pipe.publish(pipe, topic, payload)
+      {:ok, package} = :gen_tcp.recv(context.server, 0)
+      assert %Package.Publish{topic: ^topic, payload: ^payload} = Package.decode(package)
+    end
+
+    test "replace pipe during a publish if the socket is closed (active:false)", context do
+      client_id = context.test
+      parent = self()
+      publish = %Package.Publish{topic: "foo"}
+
+      subscriber =
+        spawn_link(fn ->
+          pipe = Pipe.new(client_id)
+          send(parent, {:subscriber_pipe, pipe})
+          pipe = Pipe.publish(pipe, "foo")
+          # Now the parent will close the socket belonging to the pipe
+          # and start a new one. The next publish will get the newly
+          # created socket when it attempt to publish.
+          receive do
+            :retry_publish ->
+              # this publish should receive the new pipe
+              pipe = Pipe.publish(pipe, "foo")
+              send(parent, {:subscriber_pipe, pipe})
+          end
+        end)
+
+      assert_receive {:subscriber_pipe, %Pipe{socket: original_socket}}
+      {:ok, package} = :gen_tcp.recv(context.server, 0)
+      assert Package.decode(package) == publish
+      :ok = :gen_tcp.close(context.client)
+
+      send(subscriber, :retry_publish)
+      context = run_setup(context, :setup_connection)
+
+      {:ok, package} = :gen_tcp.recv(context.server, 0)
+      assert Package.decode(package) == publish
+      assert_receive {:subscriber_pipe, %Pipe{socket: new_socket}}
+      # the new socket should be different than the original socket
+      refute new_socket == original_socket
+    end
+  end
+
+  # describe "publish/3" do
+  #   # test "pipe", context do
+  #   #   # is this actually smart? or am i abusing "into" here?
+  #   #   [
+  #   #     %Package.Publish{topic: "hello", payload: "foo"},
+  #   #     %Package.Publish{topic: "hello2", payload: "bar"},
+  #   #     %Package.Publish{topic: "hello3", payload: "baz"}
+  #   #   ]
+  #   #   |> Enum.into(%Pipe{client_id: context.client_id, socket: context.client})
+  #   # end
+  # end
 end


### PR DESCRIPTION
This PR aims to revamp the user facing publish interface such that:

`Tortoise.publish/4`, where arguments are `client_id`, `topic`, `payload` (default: `nil`), and `opts` (default `[qos: 0]`)

`Tortoise.publish_sync/5`, where arguments are `client_id`, `topic`, `payload` (default: `nil`), `opts` (default `[qos: 0]`), and lastly a `timeout` (default `:infinity`)

The `publish_sync` form will block the caller until the message has been delivered—when sync publishing a QoS0 message that will be instantly. When using the non-sync form a message will get passed to the calling process, unless the QoS is 0—I will revamp the internal messages that communicate back to the calling process as well in this PR, so the returned message has the form `{{Tortoise, client_id}, ref, result}`.

Furthermore I will reintroduce publishing using pipes before merging this PR.

Fix #2 