### PR TITLE
start application on start

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,6 @@ I would love to get some feedback and help building this thing.
 Just to get people started:
 
 ``` elixir
-# make sure the application is started
-Tortoise.start(:temporary, [])
-
 # connect to the server and subscribe to foo/bar
 Tortoise.Supervisor.start_child(
     client_id: "my_client_id",

--- a/mix.exs
+++ b/mix.exs
@@ -14,7 +14,8 @@ defmodule Tortoise.MixProject do
   # Run "mix help compile.app" to learn about applications.
   def application do
     [
-      extra_applications: [:logger]
+      extra_applications: [:logger],
+      mod: {Tortoise, []}
     ]
   end
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -302,8 +302,6 @@ defmodule Tortoise.TestTCPTunnel do
   end
 end
 
-{:ok, _} = Tortoise.start(:temporary, [])
-
 {:ok, _acceptor_pid} = Tortoise.TestTCPTunnel.start_link()
 
 ExUnit.start()


### PR DESCRIPTION
Currently, the Tortoise application does not start on boot. This leaves the consumer to have to manually start this application in the consumer's source code. The expected behavior is that Tortoise will start its supervison tree on boot.