### PR TITLE
Track and reflect subscriptions and unsubscriptions in Tortoise.Connection

### DIFF
--- a/lib/tortoise.ex
+++ b/lib/tortoise.ex
@@ -13,14 +13,14 @@ defmodule Tortoise do
   defdelegate publish_sync(client_id, topic, payload \\ nil, opts \\ [], timeout \\ :infinity),
     to: Tortoise.Connection
 
-  def subscribe(client_id, [{_, n} | _] = topics) when is_number(n) do
-    subscribe = Enum.into(topics, %Tortoise.Package.Subscribe{})
-    Inflight.track_sync(client_id, {:outgoing, subscribe}, 5000)
-  end
+  # def subscribe(client_id, [{_, n} | _] = topics) when is_number(n) do
+  #   subscribe = Enum.into(topics, %Tortoise.Package.Subscribe{})
+  #   Inflight.track_sync(client_id, {:outgoing, subscribe}, 5000)
+  # end
 
-  def subscribe(client_id, {_, n} = topic) when is_number(n) do
-    subscribe(client_id, [topic])
-  end
+  # def subscribe(client_id, {_, n} = topic) when is_number(n) do
+  #   subscribe(client_id, [topic])
+  # end
 
   def unsubscribe(client_id, topics) when is_list(topics) do
     unsubscribe = %Tortoise.Package.Unsubscribe{topics: topics}

--- a/lib/tortoise.ex
+++ b/lib/tortoise.ex
@@ -3,8 +3,6 @@ defmodule Tortoise do
   Documentation for Tortoise.
   """
 
-  alias Tortoise.Connection.Inflight
-
   @doc """
   Publish a message to the MQTT broker
   """
@@ -13,23 +11,9 @@ defmodule Tortoise do
   defdelegate publish_sync(client_id, topic, payload \\ nil, opts \\ [], timeout \\ :infinity),
     to: Tortoise.Connection
 
-  # def subscribe(client_id, [{_, n} | _] = topics) when is_number(n) do
-  #   subscribe = Enum.into(topics, %Tortoise.Package.Subscribe{})
-  #   Inflight.track_sync(client_id, {:outgoing, subscribe}, 5000)
-  # end
+  defdelegate subscribe(client_id, topics, opts \\ []), to: Tortoise.Connection
 
-  # def subscribe(client_id, {_, n} = topic) when is_number(n) do
-  #   subscribe(client_id, [topic])
-  # end
-
-  def unsubscribe(client_id, topics) when is_list(topics) do
-    unsubscribe = %Tortoise.Package.Unsubscribe{topics: topics}
-    Inflight.track_sync(client_id, {:outgoing, unsubscribe}, 5000)
-  end
-
-  def unsubscribe(client_id, topic) do
-    unsubscribe(client_id, [topic])
-  end
+  defdelegate unsubscribe(client_id, topics, opts \\ []), to: Tortoise.Connection
 
   # defp generate_client_id() do
   #   :crypto.strong_rand_bytes(10) |> Base.encode16()

--- a/lib/tortoise/connection.ex
+++ b/lib/tortoise/connection.ex
@@ -98,11 +98,15 @@ defmodule Tortoise.Connection do
   def subscribe(client_id, [{_, n} | _] = topics, opts) when is_number(n) do
     identifier = Keyword.get(opts, :identifier, nil)
     subscribe = Enum.into(topics, %Package.Subscribe{identifier: identifier})
-    Inflight.track(client_id, {:outgoing, subscribe})
+    GenServer.call(via_name(client_id), {:subscribe, subscribe})
   end
 
   def subscribe(client_id, {_, n} = topic, opts) when is_number(n) do
     subscribe(client_id, [topic], opts)
+  end
+
+  def subscriptions(client_id) do
+    GenServer.call(via_name(client_id), :subscriptions)
   end
 
   # Callbacks
@@ -146,16 +150,18 @@ defmodule Tortoise.Connection do
 
       false ->
         # subscribe to the predefined topics
-        {:ok, ref} = Inflight.track(client_id, {:outgoing, subscriptions})
-
-        receive do
-          {Tortoise, {{^client_id, ^ref}, _result}} ->
-            # todo, handle topics that had errors like "access denied"
-            # todo, handle topics that got a lower qos than expected
-            {:noreply, state}
-        after
-          5000 ->
+        case Inflight.track_sync(client_id, {:outgoing, subscriptions}, 5000) do
+          {:error, :timeout} ->
             {:stop, :subscription_timeout, state}
+
+          result ->
+            case handle_suback_result(result, state) do
+              {:ok, updated_state} ->
+                {:noreply, updated_state}
+
+              {:error, final_state} ->
+                {:stop, :unable_to_subscribe, final_state}
+            end
         end
     end
   end
@@ -185,7 +191,41 @@ defmodule Tortoise.Connection do
     do_attempt_reconnect(state)
   end
 
+  # subscribing
+  def handle_call({:subscribe, subscribe}, from, state) do
+    client_id = state.connect.client_id
+
+    case Inflight.track_sync(client_id, {:outgoing, subscribe}, 5000) do
+      {:error, :timeout} = error ->
+        {:reply, error, state}
+
+      result ->
+        case handle_suback_result(result, state) do
+          {:ok, updated_state} ->
+            {:reply, :ok, updated_state}
+
+          {:error, reasons} ->
+            error = {:unable_to_subscribe, reasons}
+            GenServer.reply(from, {:error, error})
+            {:stop, error, state}
+        end
+    end
+  end
+
+  def handle_call(:subscriptions, _from, state) do
+    {:reply, state.subscriptions, state}
+  end
+
   # Helpers
+  defp handle_suback_result(%{:error => []} = results, %State{} = state) do
+    subscriptions = Enum.into(results[:ok], state.subscriptions)
+    {:ok, %State{state | subscriptions: subscriptions}}
+  end
+
+  defp handle_suback_result(%{:error => errors}, %State{}) do
+    {:error, errors}
+  end
+
   defp reset_keep_alive(%State{keep_alive: nil} = state) do
     ref = Process.send_after(self(), :ping, state.connect.keep_alive * 1000)
     %State{state | keep_alive: ref}

--- a/lib/tortoise/connection.ex
+++ b/lib/tortoise/connection.ex
@@ -26,8 +26,13 @@ defmodule Tortoise.Connection do
     }
 
     subscriptions =
-      Keyword.get(opts, :subscriptions, [])
-      |> Enum.into(%Tortoise.Package.Subscribe{})
+      case Keyword.get(opts, :subscriptions, []) do
+        topics when is_list(topics) ->
+          Enum.into(topics, %Package.Subscribe{})
+
+        %Package.Subscribe{} = subscribe ->
+          subscribe
+      end
 
     # @todo, validate that the driver is valid
     opts = Keyword.take(opts, [:client_id, :driver])

--- a/lib/tortoise/connection.ex
+++ b/lib/tortoise/connection.ex
@@ -171,8 +171,9 @@ defmodule Tortoise.Connection do
               {:ok, updated_state} ->
                 {:noreply, updated_state}
 
-              {:error, final_state} ->
-                {:stop, :unable_to_subscribe, final_state}
+              {:error, reasons} ->
+                error = {:unable_to_subscribe, reasons}
+                {:stop, error, state}
             end
         end
     end

--- a/lib/tortoise/connection.ex
+++ b/lib/tortoise/connection.ex
@@ -92,6 +92,19 @@ defmodule Tortoise.Connection do
     end
   end
 
+  # subscribe/unsubscribe
+  def subscribe(client_id, topics, opts \\ [])
+
+  def subscribe(client_id, [{_, n} | _] = topics, opts) when is_number(n) do
+    identifier = Keyword.get(opts, :identifier, nil)
+    subscribe = Enum.into(topics, %Package.Subscribe{identifier: identifier})
+    Inflight.track(client_id, {:outgoing, subscribe})
+  end
+
+  def subscribe(client_id, {_, n} = topic, opts) when is_number(n) do
+    subscribe(client_id, [topic], opts)
+  end
+
   # Callbacks
   def init({{:tcp, _, _} = server, %Connect{} = connect, subscriptions, opts}) do
     expected_connack = %Connack{status: :accepted, session_present: false}

--- a/lib/tortoise/connection/controller.ex
+++ b/lib/tortoise/connection/controller.ex
@@ -95,7 +95,7 @@ defmodule Tortoise.Connection.Controller do
   end
 
   def handle_result(client_id, %Inflight.Track{caller: {pid, ref}, result: result} = track) do
-    send(pid, {Tortoise, {{client_id, ref}, result}})
+    send(pid, {{Tortoise, client_id}, ref, result})
     GenServer.cast(via_name(client_id), {:result, track})
   end
 
@@ -326,7 +326,7 @@ defmodule Tortoise.Connection.Controller do
        ) do
     # @todo, figure out what to do when a qos is return than the one requested
     updated_driver_state =
-      Enum.reduce(subacks, state.driver.state, fn {:ok, {topic_filter, _qos}}, acc ->
+      Enum.reduce(subacks[:ok], state.driver.state, fn {topic_filter, _qos}, acc ->
         # notice, we ignore the reported qos here for now
         args = [:up, topic_filter, acc]
 

--- a/test/tortoise/connection/controller_test.exs
+++ b/test/tortoise/connection/controller_test.exs
@@ -302,7 +302,7 @@ defmodule Tortoise.Connection.ControllerTest do
       # the server will send back a subscription acknowledgement message
       :ok = Controller.handle_incoming(client_id, suback)
 
-      assert_receive {Tortoise, {{^client_id, ^ref}, _}}
+      assert_receive {{Tortoise, ^client_id}, ^ref, _}
       # the client callback module should get the subscribe notifications in order
       assert_receive %TestDriver{subscriptions: ["foo"]}
       assert_receive %TestDriver{subscriptions: ["bar" | _]}
@@ -315,7 +315,7 @@ defmodule Tortoise.Connection.ControllerTest do
       {:ok, package} = :gen_tcp.recv(context.server, 0, 200)
       assert ^unsubscribe = Package.decode(package)
       :ok = Controller.handle_incoming(client_id, unsuback)
-      assert_receive {Tortoise, {{^client_id, ^ref}, _}}
+      assert_receive {{Tortoise, ^client_id}, ^ref, _}
 
       # the client callback module should remove the subscriptions in order
       assert_receive %TestDriver{subscriptions: ["baz", "bar"]}

--- a/test/tortoise/connection_test.exs
+++ b/test/tortoise/connection_test.exs
@@ -224,11 +224,14 @@ defmodule Tortoise.ConnectionTest do
       assert {:ok, _pid} = Connection.start_link(opts)
       assert_receive {ScriptedMqttServer, {:received, ^connect}}
       # subscribe to a topic
-      {:ok, ref} = Tortoise.Connection.subscribe(client_id, [{"foo", 0}], identifier: 1)
+      :ok = Tortoise.Connection.subscribe(client_id, [{"foo", 0}], identifier: 1)
 
       assert_receive {ScriptedMqttServer, {:received, %Package.Subscribe{topics: [{"foo", 0}]}}}
 
-      assert_receive {Tortoise, {{^client_id, ^ref}, [ok: {"foo", 0}]}}
+      assert %Package.Subscribe{topics: subscriptions} =
+               Tortoise.Connection.subscriptions(client_id)
+
+      assert subscriptions == [{"foo", 0}]
 
       assert_receive {ScriptedMqttServer, :completed}
     end

--- a/test/tortoise/connection_test.exs
+++ b/test/tortoise/connection_test.exs
@@ -195,23 +195,25 @@ defmodule Tortoise.ConnectionTest do
     end
   end
 
-  describe "subscribing" do
+  describe "subscriptions" do
     setup [:setup_scripted_mqtt_server]
 
     test "successful subscription", context do
       client_id = context.client_id
 
       connect = %Package.Connect{client_id: client_id, clean_session: true}
-      subscription = Enum.into([{"foo", 0}], %Package.Subscribe{identifier: 1})
-      unsubscribe = %Package.Unsubscribe{identifier: 2, topics: ["foo"]}
+      subscription_foo = Enum.into([{"foo", 0}], %Package.Subscribe{identifier: 1})
+      subscription_bar = Enum.into([{"bar", 0}], %Package.Subscribe{identifier: 2})
 
       script = [
         {:receive, connect},
         {:send, %Package.Connack{status: :accepted, session_present: false}},
-        {:receive, subscription},
+        # subscribe to foo with qos 0
+        {:receive, subscription_foo},
         {:send, %Package.Suback{identifier: 1, acks: [{:ok, 0}]}},
-        {:receive, unsubscribe},
-        {:send, %Package.Unsuback{identifier: 2}}
+        # subscribe to bar with qos 0
+        {:receive, subscription_bar},
+        {:send, %Package.Suback{identifier: 2, acks: [{:ok, 0}]}}
       ]
 
       {:ok, {ip, port}} = ScriptedMqttServer.enact(context.scripted_mqtt_server, script)
@@ -222,21 +224,69 @@ defmodule Tortoise.ConnectionTest do
         driver: {Tortoise.Driver.Default, []}
       ]
 
+      # connection
       assert {:ok, _pid} = Connection.start_link(opts)
       assert_receive {ScriptedMqttServer, {:received, ^connect}}
 
-      # subscribe to a topic
+      # subscribe to a foo
       :ok = Tortoise.Connection.subscribe(client_id, {"foo", 0}, identifier: 1)
-      assert_receive {ScriptedMqttServer, {:received, ^subscription}}
+      assert_receive {ScriptedMqttServer, {:received, ^subscription_foo}}
+      assert Enum.member?(Tortoise.Connection.subscriptions(client_id), {"foo", 0})
 
-      assert %Package.Subscribe{topics: subscriptions} =
-               Tortoise.Connection.subscriptions(client_id)
+      # subscribe to a bar
+      :ok = Tortoise.Connection.subscribe(client_id, {"bar", 0}, identifier: 2)
+      assert_receive {ScriptedMqttServer, {:received, ^subscription_bar}}
+      # both foo and bar should now be in the subscription list
+      subscriptions = Tortoise.Connection.subscriptions(client_id)
+      assert Enum.member?(subscriptions, {"foo", 0})
+      assert Enum.member?(subscriptions, {"bar", 0})
 
-      assert subscriptions == [{"foo", 0}]
+      # done
+      assert_receive {ScriptedMqttServer, :completed}
+    end
+
+    test "successful unsubscribe", context do
+      client_id = context.client_id
+
+      connect = %Package.Connect{client_id: client_id, clean_session: true}
+      unsubscribe_foo = %Package.Unsubscribe{identifier: 2, topics: ["foo"]}
+      unsubscribe_bar = %Package.Unsubscribe{identifier: 3, topics: ["bar"]}
+
+      script = [
+        {:receive, connect},
+        {:send, %Package.Connack{status: :accepted, session_present: false}},
+        {:receive, %Package.Subscribe{topics: [{"foo", 0}, {"bar", 2}], identifier: 1}},
+        {:send, %Package.Suback{acks: [ok: 0, ok: 2], identifier: 1}},
+        # unsubscribe foo
+        {:receive, unsubscribe_foo},
+        {:send, %Package.Unsuback{identifier: 2}},
+        # unsubscribe bar
+        {:receive, unsubscribe_bar},
+        {:send, %Package.Unsuback{identifier: 3}}
+      ]
+
+      {:ok, {ip, port}} = ScriptedMqttServer.enact(context.scripted_mqtt_server, script)
+
+      opts = [
+        client_id: client_id,
+        server: {:tcp, ip, port},
+        driver: {Tortoise.Driver.Default, []},
+        subscriptions: %Package.Subscribe{topics: [{"foo", 0}, {"bar", 2}], identifier: 1}
+      ]
+
+      assert {:ok, _pid} = Connection.start_link(opts)
+      assert_receive {ScriptedMqttServer, {:received, ^connect}}
 
       # now let us try to unsubscribe from foo
       :ok = Tortoise.Connection.unsubscribe(client_id, "foo", identifier: 2)
-      assert_receive {ScriptedMqttServer, {:received, ^unsubscribe}}
+      assert_receive {ScriptedMqttServer, {:received, ^unsubscribe_foo}}
+
+      assert %Package.Subscribe{topics: [{"bar", 2}]} =
+               Tortoise.Connection.subscriptions(client_id)
+
+      # and unsubscribe from bar
+      :ok = Tortoise.Connection.unsubscribe(client_id, "bar", identifier: 3)
+      assert_receive {ScriptedMqttServer, {:received, ^unsubscribe_bar}}
       assert %Package.Subscribe{topics: []} = Tortoise.Connection.subscriptions(client_id)
 
       assert_receive {ScriptedMqttServer, :completed}


### PR DESCRIPTION
Have the Connection process keep track of the subscription state so it can reconnect to the expected topics if it happens to reconnect with a clean state.

A list of topics are given at configuration time, but it is possible to subscribe (and unsubscribe) after the initialisation, so this aims to make it capable of reflecting the subscription changes in the subscription struct held in the connection process state.

When done and applied: Fixes #10 