### PR TITLE
Add ex_doc and an ex_doc setup to the project

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,19 @@ Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_do
 and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
 be found at [https://hexdocs.pm/tortoise](https://hexdocs.pm/tortoise).
 
+## Building documentation
+
+To build the documentation run the following command in a terminal emulator:
+
+``` shell
+MIX_ENV=docs mix docs
+```
+
+This will build the documentation in place them in the *doc*-folder in
+the root of the project. These docs will also find their way to the
+Hexdocs website when they project has been published on Hex in the
+future.
+
 ## License
 
 Copyright 2018 Martin Gausby

--- a/mix.exs
+++ b/mix.exs
@@ -1,14 +1,17 @@
 defmodule Tortoise.MixProject do
   use Mix.Project
 
+  @version "0.1.0"
+
   def project do
     [
       app: :tortoise,
-      version: "0.1.0",
-      elixir: "~> 1.6.3",
+      version: @version,
+      elixir: "~> 1.6.5",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
-      dialyzer: dialyzer()
+      dialyzer: dialyzer(),
+      docs: docs()
     ]
   end
 
@@ -25,7 +28,21 @@ defmodule Tortoise.MixProject do
     [
       {:gen_state_machine, "~> 2.0.2"},
       {:eqc_ex, "~> 1.4"},
-      {:dialyxir, "~> 0.5", only: [:dev, :test], runtime: false}
+      {:dialyxir, "~> 0.5", only: [:dev, :test], runtime: false},
+      {:ex_doc, "~> 0.18", only: :docs}
+    ]
+  end
+
+  defp docs() do
+    [
+      main: "readme",
+      name: "Tortoise",
+      source_ref: "v#{@version}",
+      canonical: "http://hexdocs.pm/tortoise",
+      source_url: "https://github.com/gausby/tortoise",
+      extras: [
+        "README.md"
+      ]
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,7 @@
 %{
   "dialyxir": {:hex, :dialyxir, "0.5.1", "b331b091720fd93e878137add264bac4f644e1ddae07a70bf7062c7862c4b952", [], [], "hexpm"},
+  "earmark": {:hex, :earmark, "1.2.5", "4d21980d5d2862a2e13ec3c49ad9ad783ffc7ca5769cf6ff891a4553fbaae761", [:mix], [], "hexpm"},
   "eqc_ex": {:hex, :eqc_ex, "1.4.2", "c89322cf8fbd4f9ddcb18141fb162a871afd357c55c8c0198441ce95ffe2e105", [], [], "hexpm"},
+  "ex_doc": {:hex, :ex_doc, "0.18.3", "f4b0e4a2ec6f333dccf761838a4b253d75e11f714b85ae271c9ae361367897b7", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
   "gen_state_machine": {:hex, :gen_state_machine, "2.0.2", "52abcba0981a058940c2a9b33b704e126d808418a6e85d45fa466d7450a90381", [:mix], [], "hexpm"},
 }


### PR DESCRIPTION
To build the documentation run the following in a terminal emulator:

``` shell
MIX_ENV=docs mix docs
```

This will build the documentation and place it in a folder called *doc* in the root of the project.