### PR TITLE
Let the callback module decide what to do with failing subscriptions

### DIFF
--- a/lib/tortoise/handler/logger.ex
+++ b/lib/tortoise/handler/logger.ex
@@ -27,6 +27,16 @@ defmodule Tortoise.Handler.Logger do
     {:ok, state}
   end
 
+  def subscription({:warn, [requested: req, accepted: qos]}, topic, state) do
+    Logger.warn("Subscribed to #{topic}; requested #{req} but got accepted with QoS #{qos}")
+    {:ok, state}
+  end
+
+  def subscription({:error, reason}, topic, state) do
+    Logger.error("Error subscribing to #{topic}; #{inspect(reason)}")
+    {:ok, state}
+  end
+
   def subscription(:down, topic, state) do
     Logger.info("Unsubscribed from #{topic}")
     {:ok, state}


### PR DESCRIPTION
This pass the result of subscriptions that failed (was denied) or was accepted with a different QoS than the one requested. In these cases the `subscription/3` callback will get called on the user defined handler module, such that:

- `subscription({:error, reason = :access_deined}, topic_filter, state) -> …`
- `subscription({:warn, [requested: 2, accepted: 0]}, topic_filter, state) -> …`

This will allow the user to decide on what to do in these cases, and if no special action is taken it will crash the client with a reasonable function clause error message.

For now the only error reason handled in the error case is `:access_denied`. When we get support for MQTT 5 there will be more kinds of errors that can be returned.

When applied this should fix #27 