### PR TITLE
Support multiple transport forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,25 @@
 # Changelog
 
+## upcoming
+
+- Abstract the network communication into a behaviour called
+  `Tortoise.Transport`. This behaviour specify callbacks needed to
+  connect, receive, and send messages using a network transport. It
+  also specify setting and getting options, as well as listening using
+  that network transport; the latter part is done so they can be used
+  in integration tests.
+
+- A TCP transport has been created for communicating with a broker
+  using TCP.
+
+- A SSL transport has been added to the project allowing us to connect
+  to a broker using an encrypted connection.
+
 ## 0.1.0 - 2018-05-21
 
 ### Added
 - The project is now on Hex which will hopefully broaden the user
   base. Future changes will be logged to this file.
+
 - We will from now on update the version number following Semantic
   Versioning, and major changes should get logged to this file.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## upcoming
+## 0.2.0 - 2018-05-28
+
+### Added
+
+- Experimental SSL support, please try it out and provide feedback.
 
 - Abstract the network communication into a behaviour called
   `Tortoise.Transport`. This behaviour specify callbacks needed to
@@ -10,10 +14,21 @@
   in integration tests.
 
 - A TCP transport has been created for communicating with a broker
-  using TCP.
+  using TCP. Use `Tortoise.Transport.Tcp` when specifying the server
+  in the connection to use the TCP transport.
 
-- A SSL transport has been added to the project allowing us to connect
-  to a broker using an encrypted connection.
+- A SSL transport `Tortoise.Transport.SSL` has been added to the
+  project allowing us to connect to a broker using an encrypted
+  connection.
+
+### Removed
+
+- The `{:tcp, 'localhost', 1883}` connection specification has been
+  removed in favor of `{Tortoise.Transport.Tcp, host: 'localhost',
+  port: 1883}`. This is done because we support multiple transport
+  types now, such as the `Tortoise.Transport.SSL` type (which also
+  takes a `key` and a `cert` option). The format is `{transport,
+  opts}`.
 
 ## 0.1.0 - 2018-05-21
 

--- a/README.md
+++ b/README.md
@@ -35,12 +35,25 @@ Just to get people started:
 Tortoise.Supervisor.start_child(
     client_id: "my_client_id",
     handler: {Tortoise.Handler.Logger, []},
-    server: {:tcp, 'localhost', 1883},
+    server: {Tortoise.Transport.Tcp, host: 'localhost', port: 1883},
     subscriptions: [{"foo/bar", 0}])
 
 # publish a message on the broker
 Tortoise.publish("my_client_id", "foo/bar", "Hello from the World of Tomorrow !", qos: 0)
 ```
+
+To connect to a MQTT server using SSL the `Tortoise.Transport.SSL`
+transport can be used like this:
+
+``` elixir
+Tortoise.Supervisor.start_child(
+    client_id: "my_client_id",
+    handler: {Tortoise.Handler.Logger, []},
+    server: {Tortoise.Transport.SSL, host: host, port: port, key: key, cert: cert},
+    subscriptions: [{"foo/bar", 0}])
+```
+
+Look at the `connection_test.exs`-file for an example.
 
 ## Installation
 
@@ -51,7 +64,7 @@ dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:tortoise, "~> 0.1.0"}
+    {:tortoise, "~> 0.2.0"}
   ]
 end
 ```

--- a/lib/tortoise/connection.ex
+++ b/lib/tortoise/connection.ex
@@ -288,7 +288,7 @@ defmodule Tortoise.Connection do
   defp do_connect(server, %Connect{} = connect) do
     %{type: transport, host: host, port: port, opts: opts} = server
 
-    with {:ok, socket} <- transport.connect(host, port, opts),
+    with {:ok, socket} <- transport.connect(host, port, opts, 10000),
          :ok = transport.send(socket, Package.encode(connect)),
          {:ok, packet} <- transport.recv(socket, 4, 5000) do
       case Package.decode(packet) do

--- a/lib/tortoise/connection/receiver.ex
+++ b/lib/tortoise/connection/receiver.ex
@@ -5,7 +5,7 @@ defmodule Tortoise.Connection.Receiver do
 
   alias Tortoise.Connection.{Transmitter, Controller}
 
-  defstruct client_id: nil, socket: nil, buffer: <<>>
+  defstruct client_id: nil, transport: nil, socket: nil, buffer: <<>>
   alias __MODULE__, as: State
 
   def start_link(opts) do
@@ -36,10 +36,10 @@ defmodule Tortoise.Connection.Receiver do
     }
   end
 
-  def handle_socket(client_id, {:tcp, socket}) do
-    {:ok, pid} = GenStateMachine.call(via_name(client_id), {:handle_socket, socket})
+  def handle_socket(client_id, {transport, socket}) do
+    {:ok, pid} = GenStateMachine.call(via_name(client_id), {:handle_socket, transport, socket})
 
-    case :gen_tcp.controlling_process(socket, pid) do
+    case transport.controlling_process(socket, pid) do
       :ok ->
         :ok
 
@@ -73,13 +73,17 @@ defmodule Tortoise.Connection.Receiver do
   end
 
   # activate network socket for incoming traffic
+  def handle_event(:internal, :activate_socket, _state_name, %State{transport: nil}) do
+    {:stop, :no_transport}
+  end
+
   def handle_event(:internal, :activate_socket, _state_name, data) do
-    case :inet.setopts(data.socket, active: :once) do
+    case data.transport.setopts(data.socket, active: :once) do
       :ok ->
         :keep_state_and_data
 
       {:error, :einval} ->
-        # @todo consider if there could be a we buffer should drain at this point
+        # @todo consider if there could be a buffer we should drain at this point
         {:next_state, :disconnected, data}
     end
   end
@@ -142,7 +146,7 @@ defmodule Tortoise.Connection.Receiver do
     :keep_state_and_data
   end
 
-  def handle_event({:call, from}, {:handle_socket, socket}, :disconnected, data) do
+  def handle_event({:call, from}, {:handle_socket, transport, socket}, :disconnected, data) do
     new_state = {:connected, :receiving_fixed_header}
 
     next_actions = [
@@ -153,11 +157,13 @@ defmodule Tortoise.Connection.Receiver do
     ]
 
     # better reset the buffer
-    {:next_state, new_state, %State{data | socket: socket, buffer: <<>>}, next_actions}
+    new_data = %State{data | transport: transport, socket: socket, buffer: <<>>}
+
+    {:next_state, new_state, new_data, next_actions}
   end
 
   def handle_event(:internal, :pass_socket_to_transmitter, {:connected, _}, data) do
-    :ok = Transmitter.handle_socket(data.client_id, data.socket)
+    :ok = Transmitter.handle_socket(data.client_id, {data.transport, data.socket})
     :keep_state_and_data
   end
 

--- a/lib/tortoise/transport.ex
+++ b/lib/tortoise/transport.ex
@@ -8,12 +8,32 @@ defmodule Tortoise.Transport do
   NineNines.
   """
 
+  @opaque t :: %__MODULE__{
+            type: atom(),
+            host: binary(),
+            port: non_neg_integer(),
+            opts: [term()]
+          }
+
   @enforce_keys [:type, :host, :port]
   defstruct type: nil, host: nil, port: nil, opts: []
+
+  @doc """
+  Create a new Transport specification used by the Connection process
+  to log on to the MQTT server. This allow us to filter the options
+  passed to the connection type, and guide the user to connect to the
+  individual transport type.
+  """
+  @spec new({atom(), [term()]}) :: t()
+  def new({transport, opts}) do
+    %Tortoise.Transport{type: ^transport} = transport.new(opts)
+  end
 
   @type socket() :: any()
   @type opts() :: any()
   @type stats() :: any()
+
+  @callback new(opts()) :: Transport.t()
 
   @callback listen(opts()) :: {:ok, socket()} | {:error, atom()}
 

--- a/lib/tortoise/transport.ex
+++ b/lib/tortoise/transport.ex
@@ -1,0 +1,53 @@
+defmodule Tortoise.Transport do
+  @moduledoc """
+  Abstraction for working with network connections; this is done to
+  normalize the `:ssl` and `:gen_tcp` modules, so they get a similar
+  interface.
+
+  This work has been heavily inspired by the Ranch project by
+  NineNines.
+  """
+
+  @enforce_keys [:type, :host, :port]
+  defstruct type: nil, host: nil, port: nil, opts: []
+
+  @type socket() :: any()
+  @type opts() :: any()
+  @type stats() :: any()
+
+  @callback listen(opts()) :: {:ok, socket()} | {:error, atom()}
+
+  @callback accept(socket(), timeout()) :: {:ok, socket()} | {:error, :closed | :timeout | atom()}
+
+  @callback accept_ack(socket(), timeout()) :: :ok
+
+  @callback connect(charlist(), :inet.port_number(), opts()) :: {:ok, socket()} | {:error, atom()}
+
+  @callback connect(charlist(), :inet.port_number(), opts(), timeout()) ::
+              {:ok, socket()} | {:error, atom()}
+
+  @callback recv(socket(), non_neg_integer(), timeout()) ::
+              {:ok, any()} | {:error, :closed | :timeout | atom()}
+
+  @callback send(socket(), iodata()) :: :ok | {:error, atom()}
+
+  @callback setopts(socket(), opts()) :: :ok | {:error, atom()}
+
+  @callback getopts(socket(), [atom()]) :: {:ok, opts()} | {:error, atom()}
+
+  @callback getstat(socket()) :: {:ok, stats()} | {:error, atom()}
+
+  @callback getstat(socket(), [atom()]) :: {:ok, stats()} | {:error, atom()}
+
+  @callback controlling_process(socket(), pid()) :: :ok | {:error, :closed | :now_owner | atom()}
+
+  @callback peername(socket()) ::
+              {:ok, {:inet.ip_address(), :inet.port_number()}} | {:error, atom()}
+
+  @callback sockname(socket()) ::
+              {:ok, {:inet.ip_address(), :inet.port_number()}} | {:error, atom()}
+
+  @callback shutdown(socket(), :read | :write | :read_write) :: :ok | {:error, atom()}
+
+  @callback close(socket()) :: :ok
+end

--- a/lib/tortoise/transport.ex
+++ b/lib/tortoise/transport.ex
@@ -21,8 +21,6 @@ defmodule Tortoise.Transport do
 
   @callback accept_ack(socket(), timeout()) :: :ok
 
-  @callback connect(charlist(), :inet.port_number(), opts()) :: {:ok, socket()} | {:error, atom()}
-
   @callback connect(charlist(), :inet.port_number(), opts(), timeout()) ::
               {:ok, socket()} | {:error, atom()}
 

--- a/lib/tortoise/transport/ssl.ex
+++ b/lib/tortoise/transport/ssl.ex
@@ -38,11 +38,6 @@ defmodule Tortoise.Transport.SSL do
     end
   end
 
-  def connect(host, port, opts) do
-    # [:binary, active: false, packet: :raw]
-    :ssl.connect(host, port, opts)
-  end
-
   def connect(host, port, opts, timeout) do
     # [:binary, active: false, packet: :raw]
     :ssl.connect(host, port, opts, timeout)

--- a/lib/tortoise/transport/ssl.ex
+++ b/lib/tortoise/transport/ssl.ex
@@ -1,0 +1,94 @@
+defmodule Tortoise.Transport.SSL do
+  @moduledoc false
+
+  @behaviour Tortoise.Transport
+
+  def listen(opts) do
+    case Keyword.has_key?(opts, :cert) do
+      true ->
+        :ssl.listen(0, opts)
+
+      false ->
+        throw("Please specify the cert key for the SSL transport")
+    end
+  end
+
+  def accept(listen_socket, timeout) do
+    :ssl.transport_accept(listen_socket, timeout)
+  end
+
+  def accept_ack(client_socket, timeout) do
+    case :ssl.ssl_accept(client_socket, timeout) do
+      :ok ->
+        :ok
+
+      # abnormal data sent to socket
+      {:error, {:tls_alert, _}} ->
+        :ok = close(client_socket)
+        exit(:normal)
+
+      # Socket most likely stopped responding, don't error out.
+      {:error, reason} when reason in [:timeout, :closed] ->
+        :ok = close(client_socket)
+        exit(:normal)
+
+      {:error, reason} ->
+        :ok = close(client_socket)
+        throw(reason)
+    end
+  end
+
+  def connect(host, port, opts) do
+    # [:binary, active: false, packet: :raw]
+    :ssl.connect(host, port, opts)
+  end
+
+  def connect(host, port, opts, timeout) do
+    # [:binary, active: false, packet: :raw]
+    :ssl.connect(host, port, opts, timeout)
+  end
+
+  def recv(socket, length, timeout) do
+    :ssl.recv(socket, length, timeout)
+  end
+
+  def send(socket, data) do
+    :ssl.send(socket, data)
+  end
+
+  def setopts(socket, opts) do
+    :ssl.setopts(socket, opts)
+  end
+
+  def getopts(socket, opts) do
+    :ssl.getopts(socket, opts)
+  end
+
+  def getstat(socket) do
+    :ssl.getstat(socket)
+  end
+
+  def getstat(socket, opt_names) do
+    :ssl.getstat(socket, opt_names)
+  end
+
+  def controlling_process(socket, pid) do
+    :ssl.controlling_process(socket, pid)
+  end
+
+  def peername(socket) do
+    :ssl.peername(socket)
+  end
+
+  def sockname(socket) do
+    :ssl.sockname(socket)
+  end
+
+  def shutdown(socket, mode) when mode in [:read, :write, :read_write] do
+    :ssl.shutdown(socket, mode)
+  end
+
+  def close(socket) do
+    :ssl.close(socket)
+  end
+end

--- a/lib/tortoise/transport/tcp.ex
+++ b/lib/tortoise/transport/tcp.ex
@@ -3,18 +3,13 @@ defmodule Tortoise.Transport.Tcp do
 
   @behaviour Tortoise.Transport
 
-  def listen(opts) do
-    # forced_opts = [:binary, active: false, packet: :raw, reuseaddr: true]
-    # opts = Keyword.merge(opts, forced_opts)
-    :gen_tcp.listen(0, opts)
-  end
+  alias Tortoise.Transport
 
-  def accept(listen_socket, timeout) do
-    :gen_tcp.accept(listen_socket, timeout)
-  end
-
-  def accept_ack(_socket, _timeout) do
-    :ok
+  def new(opts) do
+    {host, opts} = Keyword.pop(opts, :host)
+    {port, opts} = Keyword.pop(opts, :port, 1883)
+    opts = [:binary, {:packet, :raw}, {:active, false} | opts]
+    %Transport{type: __MODULE__, host: host, port: port, opts: opts}
   end
 
   def connect(host, port, opts, timeout) do
@@ -65,5 +60,19 @@ defmodule Tortoise.Transport.Tcp do
 
   def close(socket) do
     :gen_tcp.close(socket)
+  end
+
+  def listen(opts) do
+    # forced_opts = [:binary, active: false, packet: :raw, reuseaddr: true]
+    # opts = Keyword.merge(opts, forced_opts)
+    :gen_tcp.listen(0, opts)
+  end
+
+  def accept(listen_socket, timeout) do
+    :gen_tcp.accept(listen_socket, timeout)
+  end
+
+  def accept_ack(_socket, _timeout) do
+    :ok
   end
 end

--- a/lib/tortoise/transport/tcp.ex
+++ b/lib/tortoise/transport/tcp.ex
@@ -1,0 +1,75 @@
+defmodule Tortoise.Transport.Tcp do
+  @moduledoc false
+
+  @behaviour Tortoise.Transport
+
+  def listen(opts) do
+    # forced_opts = [:binary, active: false, packet: :raw, reuseaddr: true]
+    # opts = Keyword.merge(opts, forced_opts)
+    :gen_tcp.listen(0, opts)
+  end
+
+  def accept(listen_socket, timeout) do
+    :gen_tcp.accept(listen_socket, timeout)
+  end
+
+  def accept_ack(_socket, _timeout) do
+    :ok
+  end
+
+  def connect(host, port, opts) do
+    # forced_opts = [:binary, active: false, packet: :raw]
+    # opts = Keyword.merge(opts, forced_opts)
+    :gen_tcp.connect(host, port, opts)
+  end
+
+  def connect(host, port, opts, timeout) do
+    # forced_opts = [:binary, active: false, packet: :raw]
+    # opts = Keyword.merge(opts, forced_opts)
+    :gen_tcp.connect(host, port, opts, timeout)
+  end
+
+  def recv(socket, length, timeout) do
+    :gen_tcp.recv(socket, length, timeout)
+  end
+
+  def send(socket, data) do
+    :gen_tcp.send(socket, data)
+  end
+
+  def setopts(socket, opts) do
+    :inet.setopts(socket, opts)
+  end
+
+  def getopts(socket, opts) do
+    :inet.getopts(socket, opts)
+  end
+
+  def getstat(socket) do
+    :inet.getstat(socket)
+  end
+
+  def getstat(socket, opt_names) do
+    :inet.getstat(socket, opt_names)
+  end
+
+  def controlling_process(socket, pid) do
+    :gen_tcp.controlling_process(socket, pid)
+  end
+
+  def peername(socket) do
+    :inet.peername(socket)
+  end
+
+  def sockname(socket) do
+    :inet.sockname(socket)
+  end
+
+  def shutdown(socket, mode) when mode in [:read, :write, :read_write] do
+    :gen_tcp.shutdown(socket, mode)
+  end
+
+  def close(socket) do
+    :gen_tcp.close(socket)
+  end
+end

--- a/lib/tortoise/transport/tcp.ex
+++ b/lib/tortoise/transport/tcp.ex
@@ -17,12 +17,6 @@ defmodule Tortoise.Transport.Tcp do
     :ok
   end
 
-  def connect(host, port, opts) do
-    # forced_opts = [:binary, active: false, packet: :raw]
-    # opts = Keyword.merge(opts, forced_opts)
-    :gen_tcp.connect(host, port, opts)
-  end
-
   def connect(host, port, opts, timeout) do
     # forced_opts = [:binary, active: false, packet: :raw]
     # opts = Keyword.merge(opts, forced_opts)

--- a/mix.exs
+++ b/mix.exs
@@ -35,7 +35,7 @@ defmodule Tortoise.MixProject do
   # Run "mix help compile.app" to learn about applications.
   def application do
     [
-      extra_applications: [:logger],
+      extra_applications: [:logger, :ssl],
       mod: {Tortoise.App, []}
     ]
   end
@@ -47,7 +47,8 @@ defmodule Tortoise.MixProject do
       {:eqc_ex, "~> 1.4"},
       {:dialyxir, "~> 0.5", only: [:dev, :test], runtime: false},
       {:excoveralls, "~> 0.8", only: :test},
-      {:ex_doc, "~> 0.18", only: :docs}
+      {:ex_doc, "~> 0.18", only: :docs},
+      {:ct_helper, github: "ninenines/ct_helper", only: :test}
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Tortoise.MixProject do
   use Mix.Project
 
-  @version "0.1.0"
+  @version "0.2.0"
 
   def project do
     [

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,6 @@
 %{
   "certifi": {:hex, :certifi, "2.3.1", "d0f424232390bf47d82da8478022301c561cf6445b5b5fb6a84d49a9e76d2639", [:rebar3], [{:parse_trans, "3.2.0", [hex: :parse_trans, repo: "hexpm", optional: false]}], "hexpm"},
+  "ct_helper": {:git, "https://github.com/ninenines/ct_helper.git", "6cf0748b5ac7bd32f8d338224b843e419b1ea7c0", []},
   "dialyxir": {:hex, :dialyxir, "0.5.1", "b331b091720fd93e878137add264bac4f644e1ddae07a70bf7062c7862c4b952", [], [], "hexpm"},
   "earmark": {:hex, :earmark, "1.2.5", "4d21980d5d2862a2e13ec3c49ad9ad783ffc7ca5769cf6ff891a4553fbaae761", [:mix], [], "hexpm"},
   "eqc_ex": {:hex, :eqc_ex, "1.4.2", "c89322cf8fbd4f9ddcb18141fb162a871afd357c55c8c0198441ce95ffe2e105", [], [], "hexpm"},

--- a/test/support/test_tcp_tunnel.exs
+++ b/test/support/test_tcp_tunnel.exs
@@ -1,0 +1,48 @@
+defmodule Tortoise.Integration.TestTCPTunnel do
+  @moduledoc """
+  Create a TCP-tunnel making it possible to use :gen_tcp.send/2-3 to
+  send to the client_socket and assert on the received data on the
+  server_socket.
+
+  This work for our Transmitter-module which is handled a TCP-socket
+  from the Receiver.
+  """
+  use GenServer
+
+  defstruct [:socket, :ip, :port]
+
+  # Client API
+  def start_link() do
+    initial_state = %__MODULE__{}
+    GenServer.start_link(__MODULE__, initial_state, name: __MODULE__)
+  end
+
+  def new() do
+    {ref, {ip, port}} = GenServer.call(__MODULE__, :create)
+    {:ok, client_socket} = :gen_tcp.connect(ip, port, [:binary, active: false])
+
+    receive do
+      {:server_socket, ^ref, server_socket} ->
+        {:ok, client_socket, server_socket}
+    after
+      1000 ->
+        throw("Could not create TCP test tunnel")
+    end
+  end
+
+  # Server callbacks
+  def init(state) do
+    {:ok, socket} = :gen_tcp.listen(0, [:binary, active: false])
+    {:ok, {ip, port}} = :inet.sockname(socket)
+    {:ok, %{state | socket: socket, ip: ip, port: port}}
+  end
+
+  def handle_call(:create, {process_pid, ref} = from, state) do
+    GenServer.reply(from, {ref, {state.ip, state.port}})
+    # the process should now wait for the caller to accept the socket
+    {:ok, server} = :gen_tcp.accept(state.socket, 200)
+    :ok = :gen_tcp.controlling_process(server, process_pid)
+    send(process_pid, {:server_socket, ref, server})
+    {:noreply, state}
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -255,6 +255,9 @@ defmodule Tortoise.TestGenerators do
   end
 end
 
+# make certs for tests using the SSL transport
+:ok = :ct_helper.make_certs_in_ets()
+
 {:ok, _} = Tortoise.Integration.TestTCPTunnel.start_link()
 
 ExUnit.start()

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,3 +1,5 @@
+Code.require_file("./support/test_tcp_tunnel.exs", __DIR__)
+
 defmodule Tortoise.TestGenerators do
   @moduledoc """
   EQC generators for generating variables and data structures useful
@@ -253,55 +255,6 @@ defmodule Tortoise.TestGenerators do
   end
 end
 
-defmodule Tortoise.TestTCPTunnel do
-  @moduledoc """
-  Create a TCP-tunnel making it possible to use :gen_tcp.send/2-3 to
-  send to the client_socket and assert on the received data on the
-  server_socket.
-
-  This work for our Transmitter-module which is handled a TCP-socket
-  from the Receiver.
-  """
-  use GenServer
-
-  defstruct [:socket, :ip, :port]
-
-  # Client API
-  def start_link() do
-    initial_state = %__MODULE__{}
-    GenServer.start_link(__MODULE__, initial_state, name: __MODULE__)
-  end
-
-  def new() do
-    {ref, {ip, port}} = GenServer.call(__MODULE__, :create)
-    {:ok, client_socket} = :gen_tcp.connect(ip, port, [:binary, active: false])
-
-    receive do
-      {:server_socket, ^ref, server_socket} ->
-        {:ok, client_socket, server_socket}
-    after
-      1000 ->
-        throw("Could not create TCP test tunnel")
-    end
-  end
-
-  # Server callbacks
-  def init(state) do
-    {:ok, socket} = :gen_tcp.listen(0, [:binary, active: false])
-    {:ok, {ip, port}} = :inet.sockname(socket)
-    {:ok, %{state | socket: socket, ip: ip, port: port}}
-  end
-
-  def handle_call(:create, {process_pid, ref} = from, state) do
-    GenServer.reply(from, {ref, {state.ip, state.port}})
-    # the process should now wait for the caller to accept the socket
-    {:ok, server} = :gen_tcp.accept(state.socket, 200)
-    :ok = :gen_tcp.controlling_process(server, process_pid)
-    send(process_pid, {:server_socket, ref, server})
-    {:noreply, state}
-  end
-end
-
-{:ok, _acceptor_pid} = Tortoise.TestTCPTunnel.start_link()
+{:ok, _} = Tortoise.Integration.TestTCPTunnel.start_link()
 
 ExUnit.start()

--- a/test/tortoise/connection/controller_test.exs
+++ b/test/tortoise/connection/controller_test.exs
@@ -107,8 +107,8 @@ defmodule Tortoise.Connection.ControllerTest do
   def setup_transmitter(context) do
     opts = [client_id: context.client_id]
     {:ok, _} = Transmitter.start_link(opts)
-    {:ok, client_socket, server_socket} = Tortoise.TestTCPTunnel.new()
-    Transmitter.handle_socket(context.test, client_socket)
+    {:ok, client_socket, server_socket} = Tortoise.Integration.TestTCPTunnel.new()
+    Transmitter.handle_socket(context.test, {Tortoise.Transport.Tcp, client_socket})
 
     {:ok, %{client: client_socket, server: server_socket}}
   end

--- a/test/tortoise/connection/receiver_test.exs
+++ b/test/tortoise/connection/receiver_test.exs
@@ -12,7 +12,7 @@ defmodule Tortoise.Connection.ReceiverTest do
 
   def setup_receiver(context) do
     opts = [client_id: context.client_id]
-    {:ok, client_socket, server_socket} = Tortoise.TestTCPTunnel.new()
+    {:ok, client_socket, server_socket} = Tortoise.Integration.TestTCPTunnel.new()
     {:ok, _} = Receiver.start_link(opts)
 
     Transmitter.handle_socket(context.test, client_socket)

--- a/test/tortoise/connection/transmitter_test.exs
+++ b/test/tortoise/connection/transmitter_test.exs
@@ -15,8 +15,8 @@ defmodule Tortoise.Connection.TransmitterTest do
   end
 
   def setup_connection(context) do
-    {:ok, client_socket, server_socket} = Tortoise.TestTCPTunnel.new()
-    :ok = Transmitter.handle_socket(context.test, client_socket)
+    {:ok, client_socket, server_socket} = Tortoise.Integration.TestTCPTunnel.new()
+    :ok = Transmitter.handle_socket(context.test, {Tortoise.Transport.Tcp, client_socket})
     {:ok, %{client: client_socket, server: server_socket}}
   end
 
@@ -51,9 +51,9 @@ defmodule Tortoise.Connection.TransmitterTest do
         send(parent, {:got_socket, socket})
       end)
 
-      refute_receive {:got_socket, _socket}
+      refute_receive {:got_socket, {_transport, _socket}}
       _context = run_setup(context, :setup_connection)
-      assert_receive {:got_socket, socket}
+      assert_receive {:got_socket, {_transport, socket}}
       assert is_port(socket)
       assert Transmitter.subscribers(client_id) == []
     end
@@ -69,9 +69,9 @@ defmodule Tortoise.Connection.TransmitterTest do
           :timer.sleep(:infinity)
         end)
 
-      refute_receive {:got_socket, _socket}
+      refute_receive {:got_socket, {_transport, _socket}}
       _context = run_setup(context, :setup_connection)
-      assert_receive {:got_socket, socket}
+      assert_receive {:got_socket, {_transport, socket}}
       assert is_port(socket)
       assert Transmitter.subscribers(client_id) == [subscriber]
     end

--- a/test/tortoise/connection_test.exs
+++ b/test/tortoise/connection_test.exs
@@ -52,7 +52,7 @@ defmodule Tortoise.ConnectionTest do
 
       opts = [
         client_id: client_id,
-        server: {:tcp, ip, port},
+        server: {Tortoise.Transport.Tcp, [host: ip, port: port]},
         handler: {Tortoise.Handler.Default, []}
       ]
 
@@ -79,7 +79,7 @@ defmodule Tortoise.ConnectionTest do
 
       opts = [
         client_id: client_id,
-        server: {:tcp, ip, port},
+        server: {Tortoise.Transport.Tcp, [host: ip, port: port]},
         handler: {Tortoise.Handler.Default, []}
       ]
 
@@ -109,7 +109,7 @@ defmodule Tortoise.ConnectionTest do
 
       opts = [
         client_id: client_id,
-        server: {:tcp, ip, port},
+        server: {Tortoise.Transport.Tcp, [host: ip, port: port]},
         handler: {Tortoise.Handler.Default, []}
       ]
 
@@ -132,7 +132,7 @@ defmodule Tortoise.ConnectionTest do
 
       opts = [
         client_id: client_id,
-        server: {:tcp, ip, port},
+        server: {Tortoise.Transport.Tcp, [host: ip, port: port]},
         handler: {Tortoise.Handler.Default, []}
       ]
 
@@ -153,7 +153,7 @@ defmodule Tortoise.ConnectionTest do
 
       opts = [
         client_id: client_id,
-        server: {:tcp, ip, port},
+        server: {Tortoise.Transport.Tcp, [host: ip, port: port]},
         handler: {Tortoise.Handler.Default, []}
       ]
 
@@ -174,7 +174,7 @@ defmodule Tortoise.ConnectionTest do
 
       opts = [
         client_id: client_id,
-        server: {:tcp, ip, port},
+        server: {Tortoise.Transport.Tcp, [host: ip, port: port]},
         handler: {Tortoise.Handler.Default, []}
       ]
 
@@ -197,7 +197,7 @@ defmodule Tortoise.ConnectionTest do
 
       opts = [
         client_id: client_id,
-        server: {:tcp, ip, port},
+        server: {Tortoise.Transport.Tcp, [host: ip, port: port]},
         handler: {Tortoise.Handler.Default, []}
       ]
 
@@ -232,7 +232,7 @@ defmodule Tortoise.ConnectionTest do
 
       opts = [
         client_id: client_id,
-        server: {:tcp, ip, port},
+        server: {Tortoise.Transport.Tcp, [host: ip, port: port]},
         handler: {Tortoise.Handler.Default, []}
       ]
 
@@ -281,7 +281,7 @@ defmodule Tortoise.ConnectionTest do
 
       opts = [
         client_id: client_id,
-        server: {:tcp, ip, port},
+        server: {Tortoise.Transport.Tcp, [host: ip, port: port]},
         handler: {Tortoise.Handler.Default, []},
         subscriptions: %Package.Subscribe{topics: [{"foo", 0}, {"bar", 2}], identifier: 1}
       ]
@@ -319,7 +319,8 @@ defmodule Tortoise.ConnectionTest do
 
       opts = [
         client_id: client_id,
-        server: {:ssl, ip, port, [key: context.key, cert: context.cert]},
+        server:
+          {Tortoise.Transport.SSL, [host: ip, port: port, key: context.key, cert: context.cert]},
         handler: {Tortoise.Handler.Default, []}
       ]
 

--- a/test/tortoise/pipe_test.exs
+++ b/test/tortoise/pipe_test.exs
@@ -22,8 +22,8 @@ defmodule Tortoise.PipeTest do
   end
 
   def setup_connection(context) do
-    {:ok, client_socket, server_socket} = Tortoise.TestTCPTunnel.new()
-    :ok = Transmitter.handle_socket(context.test, client_socket)
+    {:ok, client_socket, server_socket} = Tortoise.Integration.TestTCPTunnel.new()
+    :ok = Transmitter.handle_socket(context.test, {Tortoise.Transport.Tcp, client_socket})
     {:ok, %{client: client_socket, server: server_socket}}
   end
 


### PR DESCRIPTION
Make it possible to connect to a broker using alternative transport forms, such as ssl. To achieve this I have looked into Ranch, which does this, and will implement an abstraction aiming to normalise the interface found in the `:gen_tcp` and `:ssl` modules.
 
When applied this should fix #3 