### PR TITLE
Default ssl opts to `verify_peer`

### DIFF
--- a/lib/tortoise/transport/ssl.ex
+++ b/lib/tortoise/transport/ssl.ex
@@ -5,9 +5,12 @@ defmodule Tortoise.Transport.SSL do
 
   alias Tortoise.Transport
 
+  @default_opts [verify: :verify_peer]
+
   def new(opts) do
     {host, opts} = Keyword.pop(opts, :host)
     {port, opts} = Keyword.pop(opts, :port)
+    opts = Keyword.merge(@default_opts, opts)
     opts = [:binary, {:packet, :raw}, {:active, false} | opts]
     %Transport{type: __MODULE__, host: host, port: port, opts: opts}
   end


### PR DESCRIPTION
Forces client to either pass a list of trusted CA certificates (e.g. from the `certifi` package), or explicitly opt out of server certificate verification by passing `verify: :verify_none`.

Let's encourage safe defaults, and not make the same mistake made by many HTTP clients (*cough* `httpc` *cough*), giving users a [false sense of security](https://blog.voltone.net/post/7).