### PR TITLE
Fix an issue in the receiver that made it crash on larger messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.2.2 - 2018-05-29
+
+### Changed
+
+- Fix an issue where larger messages would crash the receiver. It has
+  been fixed and tested with messages as large as 268435455 bytes;
+  which is a pretty big MQTT message.
+
 ## 0.2.1 - 2018-05-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:tortoise, "~> 0.2.1"}
+    {:tortoise, "~> 0.2.2"}
   ]
 end
 ```

--- a/lib/tortoise/connection/receiver.ex
+++ b/lib/tortoise/connection/receiver.ex
@@ -118,7 +118,7 @@ defmodule Tortoise.Connection.Receiver do
     {:next_state, next_state, new_data, next_actions}
   end
 
-  def handle_event(:internal, :consume_buffer, {:connected, {:receiving_variable, _, _}}, _data) do
+  def handle_event(:internal, :consume_buffer, {:connected, {:receiving_variable, _}}, _data) do
     # await more bytes
     :keep_state_and_data
   end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Tortoise.MixProject do
   use Mix.Project
 
-  @version "0.2.1"
+  @version "0.2.2"
 
   def project do
     [

--- a/test/tortoise/connection/receiver_test.exs
+++ b/test/tortoise/connection/receiver_test.exs
@@ -3,8 +3,8 @@ defmodule Tortoise.Connection.ReceiverTest do
   # use EQC.ExUnit
   doctest Tortoise.Connection.Controller
 
-  # alias Tortoise.Package
-  alias Tortoise.Connection.Receiver
+  alias Tortoise.Package
+  alias Tortoise.Connection.{Receiver, Transmitter, Controller}
 
   setup context do
     {:ok, %{client_id: context.test}}
@@ -13,13 +13,45 @@ defmodule Tortoise.Connection.ReceiverTest do
   def setup_receiver(context) do
     opts = [client_id: context.client_id]
     {:ok, client_socket, server_socket} = Tortoise.Integration.TestTCPTunnel.new()
-    {:ok, _} = Receiver.start_link(opts)
-
-    Transmitter.handle_socket(context.test, client_socket)
-
+    {:ok, _pid} = Receiver.start_link(opts)
+    {:ok, _pid} = Transmitter.start_link(opts)
+    :ok = Receiver.handle_socket(context.client_id, {Tortoise.Transport.Tcp, client_socket})
     {:ok, %{client: client_socket, server: server_socket}}
   end
 
-  test "receive messages" do
+  def setup_controller(context) do
+    Registry.register(Registry.Tortoise, {Controller, context.client_id}, self())
+    :ok
+  end
+
+  describe "receiving" do
+    setup [:setup_receiver, :setup_controller]
+
+    # when a message reached a certain size an issue where the message
+    # got chunked on the connection lead to a crash in the
+    # receiver. These two tests was set in place to help ironing out
+    # this error, they should probably be refactored at some point,
+    # probably as property based tests
+
+    test "receive a message of 1460 bytes", context do
+      payload = :crypto.strong_rand_bytes(1448)
+      package = %Package.Publish{topic: "foo/bar", payload: payload}
+
+      :ok = :gen_tcp.send(context.server, Package.encode(package))
+
+      assert_receive {:"$gen_cast", {:incoming, data}}
+      assert ^package = Package.decode(data)
+    end
+
+    test "receive a larger message of about 5000 bytes", context do
+      # payload = :crypto.strong_rand_bytes(268_435_446)
+      payload = :crypto.strong_rand_bytes(5000)
+      package = %Package.Publish{topic: "foo/bar", payload: payload}
+
+      :ok = :gen_tcp.send(context.server, Package.encode(package))
+
+      assert_receive {:"$gen_cast", {:incoming, data}}, 10000
+      assert ^package = Package.decode(data)
+    end
   end
 end


### PR DESCRIPTION
When the network connection chunked a message it would end up crashing because I had goofed up a pattern match. I have added two tests, one that triggered that issue, and one that was just one byte from triggering it (on my system, at least).