### PR TITLE
gen_statem style callbacks for the user defined handler module

### DIFF
--- a/coveralls.json
+++ b/coveralls.json
@@ -1,0 +1,5 @@
+{
+    "skip_files": [
+        "tortoise/handler/"
+    ]
+}

--- a/lib/tortoise.ex
+++ b/lib/tortoise.ex
@@ -74,5 +74,9 @@ defmodule Tortoise do
   given as strings. Multiple topic filters can be given at once by
   passing in a list of strings.
   """
-  defdelegate unsubscribe(client_id, topics, opts \\ []), to: Tortoise.Connection
+  defdelegate unsubscribe(client_id, topics, opts \\ []),
+    to: Tortoise.Connection
+
+  defdelegate unsubscribe_sync(client_id, topics, opts \\ []),
+    to: Tortoise.Connection
 end

--- a/lib/tortoise.ex
+++ b/lib/tortoise.ex
@@ -63,7 +63,11 @@ defmodule Tortoise do
 
   Multiple topics can be given as a list.
   """
-  defdelegate subscribe(client_id, topics, opts \\ []), to: Tortoise.Connection
+  defdelegate subscribe(client_id, topics, opts \\ []),
+    to: Tortoise.Connection
+
+  defdelegate subscribe_sync(client_id, topics, opts \\ []),
+    to: Tortoise.Connection
 
   @doc """
   Unsubscribe from one of more topic filters. The topic filters are

--- a/lib/tortoise/connection.ex
+++ b/lib/tortoise/connection.ex
@@ -122,9 +122,15 @@ defmodule Tortoise.Connection do
   def subscribe_sync(client_id, topics, opts \\ [])
 
   def subscribe_sync(client_id, [{_, n} | _] = topics, opts) when is_number(n) do
-    identifier = Keyword.get(opts, :identifier, nil)
-    subscribe = Enum.into(topics, %Package.Subscribe{identifier: identifier})
-    GenServer.call(via_name(client_id), {:subscribe, subscribe})
+    timeout = Keyword.get(opts, :timeout, 5000)
+    {:ok, ref} = subscribe(client_id, topics, opts)
+
+    receive do
+      {{Tortoise, ^client_id}, ^ref, result} -> result
+    after
+      timeout ->
+        {:error, :timeout}
+    end
   end
 
   def subscribe_sync(client_id, {_, n} = topic, opts) when is_number(n) do
@@ -158,9 +164,15 @@ defmodule Tortoise.Connection do
   def unsubscribe_sync(client_id, topics, opts \\ [])
 
   def unsubscribe_sync(client_id, topics, opts) when is_list(topics) do
-    identifier = Keyword.get(opts, :identifier, nil)
-    unsubscribe = %Package.Unsubscribe{identifier: identifier, topics: topics}
-    GenServer.call(via_name(client_id), {:unsubscribe, unsubscribe})
+    timeout = Keyword.get(opts, :timeout, 5000)
+    {:ok, ref} = unsubscribe(client_id, topics, opts)
+
+    receive do
+      {{Tortoise, ^client_id}, ^ref, result} -> result
+    after
+      timeout ->
+        {:error, :timeout}
+    end
   end
 
   def unsubscribe_sync(client_id, topic, opts) when is_binary(topic) do
@@ -251,12 +263,15 @@ defmodule Tortoise.Connection do
     do_attempt_reconnect(state)
   end
 
+  def handle_call(:subscriptions, _from, state) do
+    {:reply, state.subscriptions, state}
+  end
+
   def handle_cast(:renew_connection, state) do
     :ok = Controller.update_connection_status(state.connect.client_id, :down)
     do_attempt_reconnect(state)
   end
 
-  # cast subscribing
   def handle_cast({:subscribe, {caller_pid, ref}, subscribe, opts}, state) do
     client_id = state.connect.client_id
     timeout = Keyword.get(opts, :timeout, 5000)
@@ -295,45 +310,6 @@ defmodule Tortoise.Connection do
         send(caller_pid, {{Tortoise, client_id}, ref, :ok})
         {:noreply, %State{state | subscriptions: subscriptions}}
     end
-  end
-
-  # subscribing
-  def handle_call({:subscribe, subscribe}, from, state) do
-    client_id = state.connect.client_id
-
-    case Inflight.track_sync(client_id, {:outgoing, subscribe}, 5000) do
-      {:error, :timeout} = error ->
-        {:reply, error, state}
-
-      result ->
-        case handle_suback_result(result, state) do
-          {:ok, updated_state} ->
-            {:reply, :ok, updated_state}
-
-          {:error, reasons} ->
-            error = {:unable_to_subscribe, reasons}
-            GenServer.reply(from, {:error, error})
-            {:stop, error, state}
-        end
-    end
-  end
-
-  def handle_call({:unsubscribe, unsubscribe}, _from, state) do
-    client_id = state.connect.client_id
-
-    case Inflight.track_sync(client_id, {:outgoing, unsubscribe}, 5000) do
-      {:error, :timeout} = error ->
-        {:reply, error, state}
-
-      unsubbed ->
-        topics = Keyword.drop(state.subscriptions.topics, unsubbed)
-        subscriptions = %Package.Subscribe{state.subscriptions | topics: topics}
-        {:reply, :ok, %State{state | subscriptions: subscriptions}}
-    end
-  end
-
-  def handle_call(:subscriptions, _from, state) do
-    {:reply, state.subscriptions, state}
   end
 
   # Helpers

--- a/lib/tortoise/connection/controller.ex
+++ b/lib/tortoise/connection/controller.ex
@@ -37,7 +37,7 @@ defmodule Tortoise.Connection.Controller do
     client_id = Keyword.fetch!(opts, :client_id)
     handler = Handler.new(Keyword.fetch!(opts, :handler))
 
-    init_state = %__MODULE__{
+    init_state = %State{
       client_id: client_id,
       handler: handler
     }
@@ -98,15 +98,15 @@ defmodule Tortoise.Connection.Controller do
   end
 
   # Server callbacks
-  def init(%__MODULE__{} = opts) do
-    case run_init_callback(opts) do
-      {:ok, %__MODULE__{} = initial_state} ->
-        {:ok, initial_state}
+  def init(%State{handler: handler} = opts) do
+    case Handler.execute(:init, handler) do
+      {:ok, %Handler{} = updated_handler} ->
+        {:ok, %State{opts | handler: updated_handler}}
     end
   end
 
-  def terminate(reason, state) do
-    _ignored = run_terminate_callback(reason, state)
+  def terminate(reason, %State{handler: handler}) do
+    _ignored = Handler.execute({:terminate, reason}, handler)
     :ok
   end
 
@@ -132,21 +132,21 @@ defmodule Tortoise.Connection.Controller do
 
   def handle_cast(
         {:result, %Inflight.Track{type: Package.Subscribe} = track},
-        state
+        %State{handler: handler} = state
       ) do
-    case run_subscription_callback(track, state) do
-      {:ok, state} ->
-        {:noreply, state}
+    case Handler.execute({:subscribe, track}, handler) do
+      {:ok, updated_handler} ->
+        {:noreply, %State{state | handler: updated_handler}}
     end
   end
 
   def handle_cast(
         {:result, %Inflight.Track{type: Package.Unsubscribe} = track},
-        state
+        %State{handler: handler} = state
       ) do
-    case run_subscription_callback(track, state) do
-      {:ok, state} ->
-        {:noreply, state}
+    case Handler.execute({:unsubscribe, track}, handler) do
+      {:ok, updated_handler} ->
+        {:noreply, %State{state | handler: updated_handler}}
     end
   end
 
@@ -154,20 +154,22 @@ defmodule Tortoise.Connection.Controller do
     {:noreply, state}
   end
 
-  def handle_cast({:update_connection_status, new_status}, %State{} = state) do
-    case run_connection_callback(new_status, %State{state | status: new_status}) do
-      {:ok, state} ->
-        {:noreply, state}
+  def handle_cast({:update_connection_status, new_status}, %State{handler: handler} = state) do
+    case Handler.execute({:connection, new_status}, handler) do
+      {:ok, updated_handler} ->
+        {:noreply, %State{state | handler: updated_handler, status: new_status}}
     end
   end
 
   # QoS LEVEL 0 ========================================================
   # commands -----------------------------------------------------------
-  defp handle_package(%Publish{qos: 0, dup: false} = publish, state) do
-    # dispatch message
-    case run_publish_callback(publish, state) do
-      {:ok, state} ->
-        {:noreply, state}
+  defp handle_package(
+         %Publish{qos: 0, dup: false} = publish,
+         %State{handler: handler} = state
+       ) do
+    case Handler.execute({:publish, publish}, handler) do
+      {:ok, updated_handler} ->
+        {:noreply, %State{state | handler: updated_handler}}
 
         # handle stop
     end
@@ -175,12 +177,15 @@ defmodule Tortoise.Connection.Controller do
 
   # QoS LEVEL 1 ========================================================
   # commands -----------------------------------------------------------
-  defp handle_package(%Publish{qos: 1} = publish, state) do
+  defp handle_package(
+         %Publish{qos: 1} = publish,
+         %State{handler: handler} = state
+       ) do
     :ok = Inflight.track(state.client_id, {:incoming, publish})
-    # dispatch message
-    case run_publish_callback(publish, state) do
-      {:ok, state} ->
-        {:noreply, state}
+
+    case Handler.execute({:publish, publish}, handler) do
+      {:ok, updated_handler} ->
+        {:noreply, %State{state | handler: updated_handler}}
     end
   end
 
@@ -192,12 +197,15 @@ defmodule Tortoise.Connection.Controller do
 
   # QoS LEVEL 2 ========================================================
   # commands -----------------------------------------------------------
-  defp handle_package(%Publish{qos: 2, dup: false} = publish, state) do
+  defp handle_package(
+         %Publish{qos: 2, dup: false} = publish,
+         %State{handler: handler} = state
+       ) do
     :ok = Inflight.track(state.client_id, {:incoming, publish})
 
-    case run_publish_callback(publish, state) do
-      {:ok, state} ->
-        {:noreply, state}
+    case Handler.execute({:publish, publish}, handler) do
+      {:ok, updated_handler} ->
+        {:noreply, %State{state | handler: updated_handler}}
     end
   end
 
@@ -283,107 +291,5 @@ defmodule Tortoise.Connection.Controller do
   defp handle_package(%Disconnect{}, state) do
     # not a server
     {:noreply, state}
-  end
-
-  # handler callbacks
-  defp run_init_callback(state) do
-    args = [state.handler.initial_args]
-
-    case apply(state.handler.module, :init, args) do
-      {:ok, initial_state} ->
-        updated_handler = %{state.handler | state: initial_state}
-        {:ok, %__MODULE__{state | handler: updated_handler}}
-    end
-  end
-
-  defp run_terminate_callback(reason, state) do
-    args = [reason, state.handler.state]
-
-    apply(state.handler.module, :terminate, args)
-  end
-
-  defp run_publish_callback(%Publish{} = publish, state) do
-    topic_list = String.split(publish.topic, "/")
-    args = [topic_list, publish.payload, state.handler.state]
-
-    case apply(state.handler.module, :handle_message, args) do
-      {:ok, updated_handler_state} ->
-        updated_handler = %{state.handler | state: updated_handler_state}
-        {:ok, %__MODULE__{state | handler: updated_handler}}
-    end
-  end
-
-  defp run_subscription_callback(
-         %Inflight.Track{type: Package.Subscribe, result: subacks},
-         state
-       ) do
-    handler_module = state.handler.module
-
-    updated_handler_state =
-      Enum.reduce(subacks, state.handler.state, fn
-        {_, []}, state ->
-          state
-
-        {:ok, oks}, state ->
-          Enum.reduce(oks, state, fn {topic_filter, _qos}, acc ->
-            args = [:up, topic_filter, acc]
-
-            case apply(handler_module, :subscription, args) do
-              {:ok, state} ->
-                state
-            end
-          end)
-
-        {:warn, warns}, state ->
-          Enum.reduce(warns, state, fn {topic_filter, warning}, acc ->
-            args = [{:warn, warning}, topic_filter, acc]
-
-            case apply(handler_module, :subscription, args) do
-              {:ok, state} ->
-                state
-            end
-          end)
-
-        {:error, errors}, state ->
-          Enum.reduce(errors, state, fn {reason, {topic_filter, _qos}}, acc ->
-            args = [{:error, reason}, topic_filter, acc]
-
-            case apply(handler_module, :subscription, args) do
-              {:ok, state} ->
-                state
-            end
-          end)
-      end)
-
-    updated_handler = %{state.handler | state: updated_handler_state}
-    {:ok, %__MODULE__{state | handler: updated_handler}}
-  end
-
-  defp run_subscription_callback(
-         %Inflight.Track{type: Package.Unsubscribe, result: unsubacks},
-         state
-       ) do
-    updated_handler_state =
-      Enum.reduce(unsubacks, state.handler.state, fn topic_filter, acc ->
-        args = [:down, topic_filter, acc]
-
-        case apply(state.handler.module, :subscription, args) do
-          {:ok, state} ->
-            state
-        end
-      end)
-
-    updated_handler = %{state.handler | state: updated_handler_state}
-    {:ok, %__MODULE__{state | handler: updated_handler}}
-  end
-
-  defp run_connection_callback(status, state) do
-    args = [status, state.handler.state]
-
-    case apply(state.handler.module, :connection, args) do
-      {:ok, updated_handler_state} ->
-        updated_handler = %{state.handler | state: updated_handler_state}
-        {:ok, %State{state | handler: updated_handler}}
-    end
   end
 end

--- a/lib/tortoise/connection/controller.ex
+++ b/lib/tortoise/connection/controller.ex
@@ -174,6 +174,13 @@ defmodule Tortoise.Connection.Controller do
     end
   end
 
+  def handle_info({:next_action, {:unsubscribe, topic} = action}, state) do
+    case Tortoise.Connection.unsubscribe(state.client_id, topic) do
+      {:ok, ref} ->
+        updated_awaiting = Map.put_new(state.awaiting, ref, action)
+        {:noreply, %State{state | awaiting: updated_awaiting}}
+    end
+  end
 
   def handle_info({{Tortoise, client_id}, ref, result}, %{client_id: client_id} = state) do
     case {result, Map.pop(state.awaiting, ref)} do

--- a/lib/tortoise/connection/controller.ex
+++ b/lib/tortoise/connection/controller.ex
@@ -99,14 +99,14 @@ defmodule Tortoise.Connection.Controller do
 
   # Server callbacks
   def init(%State{handler: handler} = opts) do
-    case Handler.execute(:init, handler) do
+    case Handler.execute(handler, :init) do
       {:ok, %Handler{} = updated_handler} ->
         {:ok, %State{opts | handler: updated_handler}}
     end
   end
 
   def terminate(reason, %State{handler: handler}) do
-    _ignored = Handler.execute({:terminate, reason}, handler)
+    _ignored = Handler.execute(handler, {:terminate, reason})
     :ok
   end
 
@@ -134,7 +134,7 @@ defmodule Tortoise.Connection.Controller do
         {:result, %Inflight.Track{type: Package.Subscribe} = track},
         %State{handler: handler} = state
       ) do
-    case Handler.execute({:subscribe, track}, handler) do
+    case Handler.execute(handler, {:subscribe, track}) do
       {:ok, updated_handler} ->
         {:noreply, %State{state | handler: updated_handler}}
     end
@@ -144,7 +144,7 @@ defmodule Tortoise.Connection.Controller do
         {:result, %Inflight.Track{type: Package.Unsubscribe} = track},
         %State{handler: handler} = state
       ) do
-    case Handler.execute({:unsubscribe, track}, handler) do
+    case Handler.execute(handler, {:unsubscribe, track}) do
       {:ok, updated_handler} ->
         {:noreply, %State{state | handler: updated_handler}}
     end
@@ -155,7 +155,7 @@ defmodule Tortoise.Connection.Controller do
   end
 
   def handle_cast({:update_connection_status, new_status}, %State{handler: handler} = state) do
-    case Handler.execute({:connection, new_status}, handler) do
+    case Handler.execute(handler, {:connection, new_status}) do
       {:ok, updated_handler} ->
         {:noreply, %State{state | handler: updated_handler, status: new_status}}
     end
@@ -167,7 +167,7 @@ defmodule Tortoise.Connection.Controller do
          %Publish{qos: 0, dup: false} = publish,
          %State{handler: handler} = state
        ) do
-    case Handler.execute({:publish, publish}, handler) do
+    case Handler.execute(handler, {:publish, publish}) do
       {:ok, updated_handler} ->
         {:noreply, %State{state | handler: updated_handler}}
 
@@ -183,7 +183,7 @@ defmodule Tortoise.Connection.Controller do
        ) do
     :ok = Inflight.track(state.client_id, {:incoming, publish})
 
-    case Handler.execute({:publish, publish}, handler) do
+    case Handler.execute(handler, {:publish, publish}) do
       {:ok, updated_handler} ->
         {:noreply, %State{state | handler: updated_handler}}
     end
@@ -203,7 +203,7 @@ defmodule Tortoise.Connection.Controller do
        ) do
     :ok = Inflight.track(state.client_id, {:incoming, publish})
 
-    case Handler.execute({:publish, publish}, handler) do
+    case Handler.execute(handler, {:publish, publish}) do
       {:ok, updated_handler} ->
         {:noreply, %State{state | handler: updated_handler}}
     end

--- a/lib/tortoise/connection/controller.ex
+++ b/lib/tortoise/connection/controller.ex
@@ -56,6 +56,10 @@ defmodule Tortoise.Connection.Controller do
     GenServer.stop(via_name(client_id))
   end
 
+  def info(client_id) do
+    GenServer.call(via_name(client_id), :info)
+  end
+
   def ping(client_id) do
     ref = make_ref()
     :ok = GenServer.cast(via_name(client_id), {:ping, {self(), ref}})
@@ -111,6 +115,10 @@ defmodule Tortoise.Connection.Controller do
   def terminate(reason, %State{handler: handler}) do
     _ignored = Handler.execute(handler, {:terminate, reason})
     :ok
+  end
+
+  def handle_call(:info, _from, state) do
+    {:reply, state, state}
   end
 
   def handle_cast({:incoming, <<package::binary>>}, state) do

--- a/lib/tortoise/handler.ex
+++ b/lib/tortoise/handler.ex
@@ -62,10 +62,10 @@ defmodule Tortoise.Handler do
         handler,
         {:unsubscribe, %Inflight.Track{type: Package.Unsubscribe, result: unsubacks}}
       ) do
-    Enum.reduce(unsubacks, {:ok, handler}, fn topic_filter, {:ok, acc} ->
-      acc.module
-      |> apply(:subscription, [:down, topic_filter, acc.state])
-      |> handle_result(acc)
+    Enum.reduce(unsubacks, {:ok, handler}, fn topic_filter, {:ok, handler} ->
+      handler.module
+      |> apply(:subscription, [:down, topic_filter, handler.state])
+      |> handle_result(handler)
 
       # _, {:stop, acc} ->
       #   {:stop, acc}

--- a/lib/tortoise/handler.ex
+++ b/lib/tortoise/handler.ex
@@ -45,12 +45,9 @@ defmodule Tortoise.Handler do
   end
 
   def execute(handler, {:connection, status}) do
-    args = [status, handler.state]
-
-    case apply(handler.module, :connection, args) do
-      {:ok, updated_state} ->
-        {:ok, %__MODULE__{handler | state: updated_state}}
-    end
+    handler.module
+    |> apply(:connection, [status, handler.state])
+    |> handle_result(handler)
   end
 
   def execute(handler, {:publish, %Package.Publish{} = publish}) do

--- a/lib/tortoise/handler.ex
+++ b/lib/tortoise/handler.ex
@@ -53,7 +53,7 @@ defmodule Tortoise.Handler do
     end
   end
 
-  def execute({:publish, publish}, %__MODULE__{} = handler) do
+  def execute({:publish, %Package.Publish{} = publish}, %__MODULE__{} = handler) do
     topic_list = String.split(publish.topic, "/")
     args = [topic_list, publish.payload, handler.state]
 

--- a/lib/tortoise/handler.ex
+++ b/lib/tortoise/handler.ex
@@ -136,7 +136,7 @@ defmodule Tortoise.Handler do
         {:ok, %__MODULE__{handler | state: updated_state, next_actions: next_actions}}
 
       {_, errors} ->
-        throw({:invalid_next_action, errors})
+        {:error, {:invalid_next_action, errors}}
     end
   end
 

--- a/test/tortoise/connection_test.exs
+++ b/test/tortoise/connection_test.exs
@@ -222,7 +222,8 @@ defmodule Tortoise.ConnectionTest do
 
       connect = %Package.Connect{client_id: client_id, clean_session: true}
       subscription_foo = Enum.into([{"foo", 0}], %Package.Subscribe{identifier: 1})
-      subscription_bar = Enum.into([{"bar", 0}], %Package.Subscribe{identifier: 2})
+      subscription_bar = Enum.into([{"bar", 1}], %Package.Subscribe{identifier: 2})
+      subscription_baz = Enum.into([{"baz", 2}], %Package.Subscribe{identifier: 3})
 
       script = [
         {:receive, connect},
@@ -232,7 +233,9 @@ defmodule Tortoise.ConnectionTest do
         {:send, %Package.Suback{identifier: 1, acks: [{:ok, 0}]}},
         # subscribe to bar with qos 0
         {:receive, subscription_bar},
-        {:send, %Package.Suback{identifier: 2, acks: [{:ok, 0}]}}
+        {:send, %Package.Suback{identifier: 2, acks: [{:ok, 1}]}},
+        {:receive, subscription_baz},
+        {:send, %Package.Suback{identifier: 3, acks: [{:ok, 2}]}}
       ]
 
       {:ok, {ip, port}} = ScriptedMqttServer.enact(context.scripted_mqtt_server, script)
@@ -253,12 +256,20 @@ defmodule Tortoise.ConnectionTest do
       assert Enum.member?(Tortoise.Connection.subscriptions(client_id), {"foo", 0})
 
       # subscribe to a bar
-      :ok = Tortoise.Connection.subscribe_sync(client_id, {"bar", 0}, identifier: 2)
+      assert {:ok, ref} = Tortoise.Connection.subscribe(client_id, {"bar", 1}, identifier: 2)
+      assert_receive {{Tortoise, ^client_id}, ^ref, :ok}
       assert_receive {ScriptedMqttServer, {:received, ^subscription_bar}}
-      # both foo and bar should now be in the subscription list
+
+      # subscribe to a baz
+      assert {:ok, ref} = Tortoise.Connection.subscribe(client_id, "baz", qos: 2, identifier: 3)
+      assert_receive {{Tortoise, ^client_id}, ^ref, :ok}
+      assert_receive {ScriptedMqttServer, {:received, ^subscription_baz}}
+
+      # foo, bar, and baz should now be in the subscription list
       subscriptions = Tortoise.Connection.subscriptions(client_id)
       assert Enum.member?(subscriptions, {"foo", 0})
-      assert Enum.member?(subscriptions, {"bar", 0})
+      assert Enum.member?(subscriptions, {"bar", 1})
+      assert Enum.member?(subscriptions, {"baz", 2})
 
       # done
       assert_receive {ScriptedMqttServer, :completed}
@@ -304,7 +315,8 @@ defmodule Tortoise.ConnectionTest do
                Tortoise.Connection.subscriptions(client_id)
 
       # and unsubscribe from bar
-      :ok = Tortoise.Connection.unsubscribe_sync(client_id, "bar", identifier: 3)
+      assert {:ok, ref} = Tortoise.Connection.unsubscribe(client_id, "bar", identifier: 3)
+      assert_receive {{Tortoise, ^client_id}, ^ref, :ok}
       assert_receive {ScriptedMqttServer, {:received, ^unsubscribe_bar}}
       assert %Package.Subscribe{topics: []} = Tortoise.Connection.subscriptions(client_id)
 

--- a/test/tortoise/connection_test.exs
+++ b/test/tortoise/connection_test.exs
@@ -297,14 +297,14 @@ defmodule Tortoise.ConnectionTest do
       assert_receive {ScriptedMqttServer, {:received, ^connect}}
 
       # now let us try to unsubscribe from foo
-      :ok = Tortoise.Connection.unsubscribe(client_id, "foo", identifier: 2)
+      :ok = Tortoise.Connection.unsubscribe_sync(client_id, "foo", identifier: 2)
       assert_receive {ScriptedMqttServer, {:received, ^unsubscribe_foo}}
 
       assert %Package.Subscribe{topics: [{"bar", 2}]} =
                Tortoise.Connection.subscriptions(client_id)
 
       # and unsubscribe from bar
-      :ok = Tortoise.Connection.unsubscribe(client_id, "bar", identifier: 3)
+      :ok = Tortoise.Connection.unsubscribe_sync(client_id, "bar", identifier: 3)
       assert_receive {ScriptedMqttServer, {:received, ^unsubscribe_bar}}
       assert %Package.Subscribe{topics: []} = Tortoise.Connection.subscriptions(client_id)
 

--- a/test/tortoise/connection_test.exs
+++ b/test/tortoise/connection_test.exs
@@ -248,12 +248,12 @@ defmodule Tortoise.ConnectionTest do
       assert_receive {ScriptedMqttServer, {:received, ^connect}}
 
       # subscribe to a foo
-      :ok = Tortoise.Connection.subscribe(client_id, {"foo", 0}, identifier: 1)
+      :ok = Tortoise.Connection.subscribe_sync(client_id, {"foo", 0}, identifier: 1)
       assert_receive {ScriptedMqttServer, {:received, ^subscription_foo}}
       assert Enum.member?(Tortoise.Connection.subscriptions(client_id), {"foo", 0})
 
       # subscribe to a bar
-      :ok = Tortoise.Connection.subscribe(client_id, {"bar", 0}, identifier: 2)
+      :ok = Tortoise.Connection.subscribe_sync(client_id, {"bar", 0}, identifier: 2)
       assert_receive {ScriptedMqttServer, {:received, ^subscription_bar}}
       # both foo and bar should now be in the subscription list
       subscriptions = Tortoise.Connection.subscriptions(client_id)

--- a/test/tortoise/handler_test.exs
+++ b/test/tortoise/handler_test.exs
@@ -46,7 +46,7 @@ defmodule Tortoise.HandlerTest do
 
   describe "execute init/1" do
     test "return ok-tuple", context do
-      assert {:ok, %Handler{}} = Handler.execute(:init, context.handler)
+      assert {:ok, %Handler{}} = Handler.execute(context.handler, :init)
       assert_receive :init
     end
   end
@@ -54,10 +54,10 @@ defmodule Tortoise.HandlerTest do
   describe "execute connection/2" do
     test "return ok-tuple", context do
       handler = set_state(context.handler, pid: self())
-      assert {:ok, %Handler{}} = Handler.execute({:connection, :up}, handler)
+      assert {:ok, %Handler{}} = Handler.execute(handler, {:connection, :up})
       assert_receive {:connection, :up}
 
-      assert {:ok, %Handler{}} = Handler.execute({:connection, :down}, handler)
+      assert {:ok, %Handler{}} = Handler.execute(handler, {:connection, :down})
       assert_receive {:connection, :down}
     end
   end
@@ -69,7 +69,7 @@ defmodule Tortoise.HandlerTest do
       topics = "foo/bar"
       publish = %Package.Publish{topic: topics, payload: payload}
 
-      assert {:ok, %Handler{}} = Handler.execute({:publish, publish}, handler)
+      assert {:ok, %Handler{}} = Handler.execute(handler, {:publish, publish})
       # the topics will be in the form of a list making it possible to
       # pattern match on the topic levels
       assert_receive {:publish, topic_list, ^payload}
@@ -90,7 +90,7 @@ defmodule Tortoise.HandlerTest do
         |> Track.update({:received, suback})
 
       handler = set_state(context.handler, pid: self())
-      assert {:ok, %Handler{}} = Handler.execute({:subscribe, result}, handler)
+      assert {:ok, %Handler{}} = Handler.execute(handler, {:subscribe, result})
 
       assert_receive {:subscription, :up, "foo"}
       assert_receive {:subscription, {:error, :access_denied}, "baz"}
@@ -110,7 +110,7 @@ defmodule Tortoise.HandlerTest do
         |> Track.update({:received, unsuback})
 
       handler = set_state(context.handler, pid: self())
-      assert {:ok, %Handler{}} = Handler.execute({:unsubscribe, result}, handler)
+      assert {:ok, %Handler{}} = Handler.execute(handler, {:unsubscribe, result})
       # we should receive two subscription down messages
       assert_receive {:subscription, :down, "foo/bar"}
       assert_receive {:subscription, :down, "baz/quun"}
@@ -120,7 +120,7 @@ defmodule Tortoise.HandlerTest do
   describe "execute terminate/2" do
     test "return ok", context do
       handler = set_state(context.handler, pid: self())
-      assert :ok = Handler.execute({:terminate, :normal}, handler)
+      assert :ok = Handler.execute(handler, {:terminate, :normal})
       assert_receive {:terminate, :normal}
     end
   end

--- a/test/tortoise/handler_test.exs
+++ b/test/tortoise/handler_test.exs
@@ -1,0 +1,127 @@
+defmodule Tortoise.HandlerTest do
+  use ExUnit.Case, async: true
+  doctest Tortoise.Handler
+
+  alias Tortoise.Handler
+  alias Tortoise.Connection.Inflight.Track
+  alias Tortoise.Package
+
+  defmodule TestHandler do
+    @behaviour Handler
+
+    def init(opts) do
+      send(opts[:pid], :init)
+      {:ok, opts}
+    end
+
+    def connection(status, state) do
+      send(state[:pid], {:connection, status})
+      {:ok, state}
+    end
+
+    def subscription(status, topic, state) do
+      send(state[:pid], {:subscription, status, topic})
+      {:ok, state}
+    end
+
+    def handle_message(topic, payload, state) do
+      send(state[:pid], {:publish, topic, payload})
+      {:ok, state}
+    end
+
+    def terminate(reason, state) do
+      send(state[:pid], {:terminate, reason})
+      :ok
+    end
+  end
+
+  setup _context do
+    handler = %Tortoise.Handler{module: TestHandler, initial_args: [pid: self()]}
+    {:ok, %{handler: handler}}
+  end
+
+  defp set_state(%Handler{module: TestHandler} = handler, update) do
+    %Handler{handler | state: update}
+  end
+
+  describe "execute init/1" do
+    test "return ok-tuple", context do
+      assert {:ok, %Handler{}} = Handler.execute(:init, context.handler)
+      assert_receive :init
+    end
+  end
+
+  describe "execute connection/2" do
+    test "return ok-tuple", context do
+      handler = set_state(context.handler, pid: self())
+      assert {:ok, %Handler{}} = Handler.execute({:connection, :up}, handler)
+      assert_receive {:connection, :up}
+
+      assert {:ok, %Handler{}} = Handler.execute({:connection, :down}, handler)
+      assert_receive {:connection, :down}
+    end
+  end
+
+  describe "execute handle_message/2" do
+    test "return ok", context do
+      handler = set_state(context.handler, pid: self())
+      payload = :crypto.strong_rand_bytes(5)
+      topics = "foo/bar"
+      publish = %Package.Publish{topic: topics, payload: payload}
+
+      assert {:ok, %Handler{}} = Handler.execute({:publish, publish}, handler)
+      # the topics will be in the form of a list making it possible to
+      # pattern match on the topic levels
+      assert_receive {:publish, topic_list, ^payload}
+      assert is_list(topic_list)
+      assert topics == Enum.join(topic_list, "/")
+    end
+  end
+
+  describe "execute subscribe/2" do
+    test "return ok", context do
+      subscribe = %Package.Subscribe{identifier: 1, topics: [{"foo", 0}, {"bar", 1}, {"baz", 0}]}
+      suback = %Package.Suback{identifier: 1, acks: [ok: 0, ok: 0, error: :access_denied]}
+      caller = {self(), make_ref()}
+
+      result =
+        Track.create({:negative, caller}, subscribe)
+        |> Track.update({:dispatched, subscribe})
+        |> Track.update({:received, suback})
+
+      handler = set_state(context.handler, pid: self())
+      assert {:ok, %Handler{}} = Handler.execute({:subscribe, result}, handler)
+
+      assert_receive {:subscription, :up, "foo"}
+      assert_receive {:subscription, {:error, :access_denied}, "baz"}
+      assert_receive {:subscription, {:warn, requested: 1, accepted: 0}, "bar"}
+    end
+  end
+
+  describe "execute unsubscribe/2" do
+    test "return ok", context do
+      unsubscribe = %Package.Unsubscribe{identifier: 1, topics: ["foo/bar", "baz/quun"]}
+      unsuback = %Package.Unsuback{identifier: 1}
+      caller = {self(), make_ref()}
+
+      result =
+        Track.create({:negative, caller}, unsubscribe)
+        |> Track.update({:dispatched, unsubscribe})
+        |> Track.update({:received, unsuback})
+
+      handler = set_state(context.handler, pid: self())
+      assert {:ok, %Handler{}} = Handler.execute({:unsubscribe, result}, handler)
+      # we should receive two subscription down messages
+      assert_receive {:subscription, :down, "foo/bar"}
+      assert_receive {:subscription, :down, "baz/quun"}
+    end
+  end
+
+  describe "execute terminate/2" do
+    test "return ok", context do
+      handler = set_state(context.handler, pid: self())
+      assert :ok = Handler.execute({:terminate, :normal}, handler)
+      assert_receive {:terminate, :normal}
+    end
+  end
+end

--- a/test/tortoise/handler_test.exs
+++ b/test/tortoise/handler_test.exs
@@ -123,6 +123,23 @@ defmodule Tortoise.HandlerTest do
       assert is_list(topic_list)
       assert topic == Enum.join(topic_list, "/")
     end
+
+    test "return ok-3 with invalid next action", context do
+      next_actions = [{:unsubscribe, "foo/bar"}, {:invalid, "bar"}]
+      opts = %{pid: self(), next_actions: next_actions}
+      handler = set_state(context.handler, opts)
+      payload = :crypto.strong_rand_bytes(5)
+      topic = "foo/bar"
+      publish = %Package.Publish{topic: topic, payload: payload}
+
+      assert {:error, {:invalid_next_action, [{:invalid, "bar"}]}} =
+               Handler.execute(handler, {:publish, publish})
+
+      # the callback is still run so lets check the received data
+      assert_receive {:publish, topic_list, ^payload}
+      assert is_list(topic_list)
+      assert topic == Enum.join(topic_list, "/")
+    end
   end
 
   describe "execute subscribe/2" do

--- a/test/tortoise/handler_test.exs
+++ b/test/tortoise/handler_test.exs
@@ -169,7 +169,7 @@ defmodule Tortoise.HandlerTest do
 
   describe "execute unsubscribe/2" do
     test "return ok", context do
-      unsubscribe = %Package.Unsubscribe{identifier: 1, topics: ["foo/bar", "baz/quun"]}
+      unsubscribe = %Package.Unsubscribe{identifier: 1, topics: ["foo/bar", "baz/quux"]}
       unsuback = %Package.Unsuback{identifier: 1}
       caller = {self(), make_ref()}
 
@@ -182,7 +182,7 @@ defmodule Tortoise.HandlerTest do
       assert {:ok, %Handler{}} = Handler.execute(handler, {:unsubscribe, result})
       # we should receive two subscription down messages
       assert_receive {:subscription, :down, "foo/bar"}
-      assert_receive {:subscription, :down, "baz/quun"}
+      assert_receive {:subscription, :down, "baz/quux"}
     end
   end
 

--- a/test/tortoise/handler_test.exs
+++ b/test/tortoise/handler_test.exs
@@ -74,14 +74,19 @@ defmodule Tortoise.HandlerTest do
 
     test "return ok-3-tuple", context do
       next_actions = [{:subscribe, "foo/bar", qos: 0}]
+
       handler =
         context.handler
         |> set_state(%{pid: self(), next_actions: next_actions})
 
-      assert {:ok, %Handler{next_actions: ^next_actions}} = Handler.execute(handler, {:connection, :up})
+      assert {:ok, %Handler{next_actions: ^next_actions}} =
+               Handler.execute(handler, {:connection, :up})
+
       assert_receive {:connection, :up}
 
-      assert {:ok, %Handler{next_actions: ^next_actions}} = Handler.execute(handler, {:connection, :down})
+      assert {:ok, %Handler{next_actions: ^next_actions}} =
+               Handler.execute(handler, {:connection, :down})
+
       assert_receive {:connection, :down}
     end
   end


### PR DESCRIPTION
When implementing a callback in the gen_statem-module, some of the callbacks accept a list of next actions. In gen_statem this allow interim states to be visited, or replying back to a caller, or stopping.

In the Tortoise.Handler the `{:ok, new_state}` given to most of the callbacks could be extended to accept `{:ok, new_state, next_actions}` where `next_actions` is a list of actions the controller should act out in the order they are defined. Actions could be:

  - `{:subscribe, topic_filter, qos: n}`
  - `{:unsubscribe, topic_filter}`
  - <strike>`{:publish, topic, payload, opts}`</strike> (will not get implemented)

Of course these actions could lead to eternal loops, but that is part of the deal. This will be set in place to give the user a way to do things "right" as all the operations will be performed async, and thus not block the controller process—which would be a problem if the user were to use the publish in the `publish_sync`-form in the callback running in the controller process.

If applied this should fix #34 and also fix #33 