### PR TITLE
Add dedicated Registry module

### DIFF
--- a/lib/tortoise/app.ex
+++ b/lib/tortoise/app.ex
@@ -11,7 +11,7 @@ defmodule Tortoise.App do
     # start with client_id, and handler from config
 
     children = [
-      {Registry, [keys: :unique, name: Registry.Tortoise]},
+      {Registry, [keys: :unique, name: Tortoise.Registry]},
       {Tortoise.Supervisor, [strategy: :one_for_one]}
     ]
 

--- a/lib/tortoise/connection.ex
+++ b/lib/tortoise/connection.ex
@@ -42,14 +42,8 @@ defmodule Tortoise.Connection do
     GenServer.start_link(__MODULE__, initial, name: via_name(client_id))
   end
 
-  def via_name(pid) when is_pid(pid), do: pid
-
-  def via_name(client_id) do
-    {:via, Registry, reg_name(client_id)}
-  end
-
-  def reg_name(client_id) do
-    {Registry.Tortoise, {__MODULE__, client_id}}
+  defp via_name(client_id) do
+    Tortoise.Registry.via_name(__MODULE__, client_id)
   end
 
   def child_spec(opts) do

--- a/lib/tortoise/connection/controller.ex
+++ b/lib/tortoise/connection/controller.ex
@@ -45,14 +45,8 @@ defmodule Tortoise.Connection.Controller do
     GenServer.start_link(__MODULE__, init_state, name: via_name(client_id))
   end
 
-  defp via_name(pid) when is_pid(pid), do: pid
-
   defp via_name(client_id) do
-    {:via, Registry, reg_name(client_id)}
-  end
-
-  def reg_name(client_id) do
-    {Registry.Tortoise, {__MODULE__, client_id}}
+    Tortoise.Registry.via_name(__MODULE__, client_id)
   end
 
   def stop(client_id) do

--- a/lib/tortoise/connection/inflight.ex
+++ b/lib/tortoise/connection/inflight.ex
@@ -19,14 +19,8 @@ defmodule Tortoise.Connection.Inflight do
     GenServer.start_link(__MODULE__, initial_state, name: via_name(client_id))
   end
 
-  def via_name(pid) when is_pid(pid), do: pid
-
-  def via_name(client_id) do
-    {:via, Registry, reg_name(client_id)}
-  end
-
-  def reg_name(client_id) do
-    {Registry.Tortoise, {__MODULE__, client_id}}
+  defp via_name(client_id) do
+    Tortoise.Registry.via_name(__MODULE__, client_id)
   end
 
   def stop(client_id) do

--- a/lib/tortoise/connection/receiver.ex
+++ b/lib/tortoise/connection/receiver.ex
@@ -16,14 +16,8 @@ defmodule Tortoise.Connection.Receiver do
     GenStateMachine.start_link(__MODULE__, data, name: via_name(client_id))
   end
 
-  defp via_name(pid) when is_pid(pid), do: pid
-
   defp via_name(client_id) do
-    {:via, Registry, reg_name(client_id)}
-  end
-
-  def reg_name(client_id) do
-    {Registry.Tortoise, {__MODULE__, client_id}}
+    Tortoise.Registry.via_name(__MODULE__, client_id)
   end
 
   def child_spec(opts) do

--- a/lib/tortoise/connection/transmitter.ex
+++ b/lib/tortoise/connection/transmitter.ex
@@ -18,14 +18,8 @@ defmodule Tortoise.Connection.Transmitter do
     GenStateMachine.start_link(__MODULE__, data, name: via_name(client_id))
   end
 
-  def via_name(pid) when is_pid(pid), do: pid
-
-  def via_name(client_id) do
-    {:via, Registry, reg_name(client_id)}
-  end
-
-  def reg_name(client_id) do
-    {Registry.Tortoise, {__MODULE__, client_id}}
+  defp via_name(client_id) do
+    Tortoise.Registry.via_name(__MODULE__, client_id)
   end
 
   def child_spec(opts) do

--- a/lib/tortoise/registry.ex
+++ b/lib/tortoise/registry.ex
@@ -1,0 +1,17 @@
+defmodule Tortoise.Registry do
+  @moduledoc false
+
+  @type client_id :: pid() | binary()
+  @type via :: {:via, Registry, {__MODULE__, {atom(), client_id()}}}
+
+  @spec via_name(atom(), client_id()) :: via()
+  def via_name(_module, client_id) when is_pid(client_id), do: client_id
+
+  def via_name(module, client_id) do
+    {:via, Registry, reg_name(module, client_id)}
+  end
+
+  defp reg_name(module, client_id) do
+    {__MODULE__, {module, client_id}}
+  end
+end

--- a/lib/tortoise/registry.ex
+++ b/lib/tortoise/registry.ex
@@ -4,7 +4,7 @@ defmodule Tortoise.Registry do
   @type client_id :: pid() | binary()
   @type via :: {:via, Registry, {__MODULE__, {atom(), client_id()}}}
 
-  @spec via_name(atom(), client_id()) :: via()
+  @spec via_name(atom(), client_id()) :: via() | pid()
   def via_name(_module, client_id) when is_pid(client_id), do: client_id
 
   def via_name(module, client_id) do

--- a/test/tortoise/connection/receiver_test.exs
+++ b/test/tortoise/connection/receiver_test.exs
@@ -20,7 +20,7 @@ defmodule Tortoise.Connection.ReceiverTest do
   end
 
   def setup_controller(context) do
-    Registry.register(Registry.Tortoise, {Controller, context.client_id}, self())
+    Registry.register(Tortoise.Registry, {Controller, context.client_id}, self())
     :ok
   end
 


### PR DESCRIPTION
This PR gathers boilerplate from the different processes which collaborate through the registry, and puts it in a central Registry module.