### PR TITLE
Reconnection retries

### DIFF
--- a/lib/tortoise/connection.ex
+++ b/lib/tortoise/connection.ex
@@ -211,6 +211,9 @@ defmodule Tortoise.Connection do
       %Connack{status: {:refused, reason}} ->
         {:stop, {:connection_failed, reason}}
 
+      {:error, {:nxdomain, host, port}} ->
+        {:stop, {:nxdomain, host, port}}
+
       {:error, {:protocol_violation, violation}} ->
         Logger.error("Protocol violation: #{inspect(violation)}")
         {:stop, :protocol_violation}
@@ -354,6 +357,9 @@ defmodule Tortoise.Connection do
     else
       {:error, :econnrefused} ->
         {:error, {:connection_refused, host, port}}
+
+      {:error, :nxdomain} ->
+        {:error, {:nxdomain, host, port}}
     end
   end
 

--- a/lib/tortoise/connection/backoff.ex
+++ b/lib/tortoise/connection/backoff.ex
@@ -1,0 +1,44 @@
+defmodule Tortoise.Connection.Backoff do
+  @moduledoc false
+
+  defstruct min_interval: 100, max_interval: 30_000, timeout: :infinity, total: 0, value: nil
+  alias __MODULE__, as: State
+
+  @doc """
+  Create an opaque data structure that describe a incremental
+  back-off.
+  """
+  def new(opts) do
+    timeout = Keyword.get(opts, :timeout, :infinity)
+    min_interval = Keyword.get(opts, :min_interval, 100)
+    max_interval = Keyword.get(opts, :max_interval, 30_000)
+    %State{min_interval: min_interval, max_interval: max_interval, timeout: timeout}
+  end
+
+  def next(%State{total: total, timeout: timeout}) when total >= timeout do
+    {:error, :timeout}
+  end
+
+  def next(%State{value: nil} = state) do
+    current = state.min_interval
+    %State{state | total: state.total + current, value: current}
+  end
+
+  def next(%State{max_interval: same, value: same} = state) do
+    current = state.min_interval
+    %State{state | total: state.total + current, value: current}
+  end
+
+  def next(%State{value: value, total: total} = state) do
+    current = min(value * 2, state.max_interval)
+    %State{state | total: total + current, value: current}
+  end
+
+  def reset(%State{} = state) do
+    %State{state | total: 0, value: nil}
+  end
+
+  def timeout(%State{value: value}) do
+    value
+  end
+end

--- a/lib/tortoise/connection/supervisor.ex
+++ b/lib/tortoise/connection/supervisor.ex
@@ -6,7 +6,12 @@ defmodule Tortoise.Connection.Supervisor do
   alias Tortoise.Connection.{Transmitter, Receiver, Controller, Inflight}
 
   def start_link(opts) do
-    Supervisor.start_link(__MODULE__, opts)
+    client_id = Keyword.fetch!(opts, :client_id)
+    Supervisor.start_link(__MODULE__, opts, name: via_name(client_id))
+  end
+
+  defp via_name(client_id) do
+    Tortoise.Registry.via_name(__MODULE__, client_id)
   end
 
   def init(opts) do

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Tortoise.MixProject do
   use Mix.Project
 
-  @version "0.3.0"
+  @version "0.4.0"
 
   def project do
     [

--- a/test/support/scripted_transport.exs
+++ b/test/support/scripted_transport.exs
@@ -1,0 +1,265 @@
+defmodule Tortoise.Integration.ScriptedTransport do
+  @moduledoc """
+  The `ScriptedTransport` is a GenServer that implement the
+  `Tortoise.Transport`-behaviour. It can be given a list of expected
+  packages, and the packages it should respond with like this:
+
+      script = [
+        {:expect, %Package.Connect{client_id: "Test"}},
+        {:dispatch, %Package.Connack{status: :accepted}}
+      ]
+
+      {:ok, _} = ScriptedTransport.start_link({'localhost', 1883}, script: script)
+
+  This will start a server which `Tortoise.Connection` can connect to
+  like this:
+
+      {:ok, _} = Tortoise.Connection.start_link(
+        client_id: "Test",
+        server: {ScriptedTransport, host: 'localhost', port: 1883},
+        handler: {Tortoise.Handler.Logger, []}
+      )
+
+  While the `Tortoise.Transport.Tcp`-transport is recommenced for most
+  test cases this transport can be used to simulate a network
+  connection sending a specific error code at a given time; a test
+  case where we need the broker to send back `{:error, :nxdomain}`
+  could look like this:
+
+      script = [
+        {:refute_connection, {:error, :nxdomain}}
+      ]
+
+      {:ok, _} = ScriptedTransport.start_link({'localhost', 1883}, script: script)
+
+  Which will send a non-existent domain error to the
+  `Tortoise.Connection` when a connection is established.
+
+  The transport will shutdown if it get an unexpected package.
+  """
+
+  import Kernel, except: [send: 2]
+
+  @behaviour Tortoise.Transport
+  alias Tortoise.Transport
+  alias __MODULE__, as: State
+
+  @enforce_keys [:script]
+  defstruct [
+    :script,
+    :client,
+    :host,
+    :port,
+    :opts,
+    :stats,
+    :status,
+    :controlling_process,
+    :buffer
+  ]
+
+  use GenServer
+
+  # Client API
+  def start_link({host, port}, opts) do
+    name = Tortoise.Registry.via_name(__MODULE__, {host, port})
+
+    defaults = [
+      host: host,
+      port: port,
+      buffer: "",
+      stats: []
+    ]
+
+    state = struct(State, Keyword.merge(defaults, opts))
+
+    GenServer.start_link(__MODULE__, state, name: name)
+  end
+
+  defp via_name({host, port}) do
+    Tortoise.Registry.via_name(__MODULE__, {host, port})
+  end
+
+  @impl true
+  def new(opts) do
+    {host, opts} = Keyword.pop(opts, :host)
+    {port, opts} = Keyword.pop(opts, :port, 1883)
+    %Transport{type: __MODULE__, host: host, port: port, opts: opts}
+  end
+
+  @impl true
+  def connect(host, port, opts, timeout) do
+    GenServer.call(via_name({host, port}), {:connect, opts, timeout})
+  end
+
+  @impl true
+  def close(socket) do
+    GenServer.call(socket, :close)
+  end
+
+  @impl true
+  def controlling_process(socket, pid) do
+    GenServer.call(socket, {:controlling_process, pid})
+  end
+
+  @impl true
+  def getopts(socket, opts) do
+    GenServer.call(socket, {:getopts, opts})
+  end
+
+  @impl true
+  def getstat(socket) do
+    GenServer.call(socket, :getstat)
+  end
+
+  @impl true
+  def getstat(socket, opt_names) do
+    GenServer.call(socket, {:getstat, opt_names})
+  end
+
+  @impl true
+  def peername(socket) do
+    GenServer.call(socket, :peername)
+  end
+
+  @impl true
+  def sockname(socket) do
+    GenServer.call(socket, :sockname)
+  end
+
+  @impl true
+  def recv(socket, length, timeout) do
+    GenServer.call(socket, {:recv, length, timeout})
+  end
+
+  @impl true
+  def send(socket, packet) do
+    GenServer.call(socket, {:send, packet})
+  end
+
+  @impl true
+  def setopts(socket, opts) do
+    GenServer.call(socket, {:setopts, opts})
+  end
+
+  @impl true
+  def shutdown(socket, mode) when mode in [:read, :write, :read_write] do
+    GenServer.call(socket, {:shutdown, mode})
+  end
+
+  @impl true
+  def listen(_opts) do
+    {:error, :not_implemented}
+  end
+
+  @impl true
+  def accept(_socket, _timeout) do
+    {:error, :not_implemented}
+  end
+
+  @impl true
+  def accept_ack(_client_socket, _timeout) do
+    {:error, :not_implemented}
+  end
+
+  # Server callbacks
+  @impl true
+  def init(%State{script: script} = state) when is_list(script) do
+    {:ok, state}
+  end
+
+  def init(_) do
+    {:stop, :no_script_specified}
+  end
+
+  @impl true
+  def handle_call(_, _, %State{status: :closed} = state) do
+    {:stop, :data_received_after_close, state}
+  end
+
+  def handle_call(
+        {:connect, _opts, _timeout},
+        _,
+        %State{client: nil, script: [{:refute_connection, reason} | remaining]} = state
+      ) do
+    {:reply, reason, %State{state | script: remaining}}
+  end
+
+  def handle_call({:connect, opts, _timeout}, {client_pid, _ref}, %State{client: nil} = state) do
+    {:reply, {:ok, self()}, %State{state | client: client_pid, status: :open, opts: opts}}
+  end
+
+  def handle_call({:connect, _, _}, _from, state) do
+    {:stop, :already_connected, state}
+  end
+
+  def handle_call(:close, _, state) do
+    {:reply, :ok, %State{state | status: :closed}}
+  end
+
+  def handle_call({:shutdown, _mode}, _from, %State{} = state) do
+    # todo: mode in [:read, :write, :read_write]
+    {:reply, :ok, state}
+  end
+
+  def handle_call({:controlling_process, pid}, _, %State{} = state) do
+    {:reply, :ok, %State{state | controlling_process: pid}}
+  end
+
+  # receive packages from the MQTT Client
+  def handle_call({:send, packet}, _, %State{script: [{:expect, expected} | remaining]} = state) do
+    case Tortoise.Package.decode(packet) do
+      ^expected ->
+        {:reply, :ok, setup_next(%State{state | script: remaining})}
+
+      unexpected ->
+        {:stop, {:unexpected_data, [got: unexpected, expected: expected]}, state}
+    end
+  end
+
+  def handle_call(
+        {:recv, length, _timeout},
+        {client_pid, _},
+        %State{client: client_pid, buffer: buffer} = state
+      )
+      when byte_size(buffer) >= length do
+    <<msg::binary-size(length), remaining::binary>> = buffer
+    {:reply, {:ok, msg}, %State{state | buffer: remaining}}
+  end
+
+  def handle_call({:recv, _length, _timeout}, {other, _ref}, %State{client: client} = state)
+      when client != other do
+    {:stop, :not_the_controlling_process, state}
+  end
+
+  def handle_call({:setopts, opts}, _from, %State{} = state) do
+    {:reply, :ok, %State{state | opts: Keyword.merge(state.opts, opts)}}
+  end
+
+  def handle_call({:getopts, _opts}, _, %State{} = state) do
+    {:reply, :na, state}
+  end
+
+  def handle_call(:getstat, _, %State{} = state) do
+    {:reply, state.stats, state}
+  end
+
+  def handle_call(:peername, _, %State{} = state) do
+    peername = {state.host, state.port}
+    {:reply, {:ok, peername}, state}
+  end
+
+  def handle_call(:sockname, _, %State{} = state) do
+    sockname = {state.host, state.port}
+    {:reply, {:ok, sockname}, state}
+  end
+
+  def handle_call({:getstat, opts}, _, %State{} = state) do
+    {:reply, Keyword.take(state.stats, opts), state}
+  end
+
+  defp setup_next(%State{script: [{:dispatch, package} | remaining]} = state) do
+    data = IO.iodata_to_binary(Tortoise.Package.encode(package))
+    buffer = state.buffer <> data
+    %State{state | script: remaining, buffer: buffer}
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -260,4 +260,4 @@ end
 
 {:ok, _} = Tortoise.Integration.TestTCPTunnel.start_link()
 
-ExUnit.start()
+ExUnit.start(capture_log: true)

--- a/test/tortoise/connection/backoff_test.exs
+++ b/test/tortoise/connection/backoff_test.exs
@@ -29,4 +29,10 @@ defmodule Tortoise.Connection.BackoffTest do
     assert %Backoff{} = backoff = Backoff.reset(backoff)
     assert ^snapshot = Backoff.next(backoff)
   end
+
+  test "get current timeout value" do
+    backoff = Backoff.new(min_interval: 10)
+    assert %Backoff{value: timeout} = backoff = Backoff.next(backoff)
+    assert ^timeout = Backoff.timeout(backoff)
+  end
 end

--- a/test/tortoise/connection/backoff_test.exs
+++ b/test/tortoise/connection/backoff_test.exs
@@ -8,31 +8,18 @@ defmodule Tortoise.Connection.BackoffTest do
     min = 100
     max = 300
     backoff = Backoff.new(min_interval: 100, max_interval: 300)
-    assert %{value: ^min} = backoff = Backoff.next(backoff)
-    backoff = Backoff.next(backoff)
-    assert %{value: ^max} = backoff = Backoff.next(backoff)
+    assert {^min, backoff} = Backoff.next(backoff)
+    {_, backoff} = Backoff.next(backoff)
+    assert {^max, backoff} = Backoff.next(backoff)
     # should roll back to min interval now
-    assert %{value: ^min} = Backoff.next(backoff)
-  end
-
-  test "should not exceed timeout value" do
-    backoff = Backoff.new(timeout: 300, min_interval: 100)
-    assert backoff = Backoff.next(backoff)
-    assert backoff = Backoff.next(backoff)
-    assert {:error, :timeout} = Backoff.next(backoff)
+    assert {^min, _} = Backoff.next(backoff)
   end
 
   test "reset" do
     backoff = Backoff.new(min_interval: 10)
-    assert backoff = snapshot = Backoff.next(backoff)
-    assert backoff = Backoff.next(backoff)
+    assert {_, backoff = snapshot} = Backoff.next(backoff)
+    assert {_, backoff} = Backoff.next(backoff)
     assert %Backoff{} = backoff = Backoff.reset(backoff)
-    assert ^snapshot = Backoff.next(backoff)
-  end
-
-  test "get current timeout value" do
-    backoff = Backoff.new(min_interval: 10)
-    assert %Backoff{value: timeout} = backoff = Backoff.next(backoff)
-    assert ^timeout = Backoff.timeout(backoff)
+    assert {_, ^snapshot} = Backoff.next(backoff)
   end
 end

--- a/test/tortoise/connection/backoff_test.exs
+++ b/test/tortoise/connection/backoff_test.exs
@@ -4,7 +4,7 @@ defmodule Tortoise.Connection.BackoffTest do
 
   alias Tortoise.Connection.Backoff
 
-  test "should next exceed maximum interval time" do
+  test "should not exceed maximum interval time" do
     min = 100
     max = 300
     backoff = Backoff.new(min_interval: 100, max_interval: 300)

--- a/test/tortoise/connection/backoff_test.exs
+++ b/test/tortoise/connection/backoff_test.exs
@@ -1,0 +1,32 @@
+defmodule Tortoise.Connection.BackoffTest do
+  use ExUnit.Case, async: true
+  doctest Tortoise.Connection.Backoff
+
+  alias Tortoise.Connection.Backoff
+
+  test "should next exceed maximum interval time" do
+    min = 100
+    max = 300
+    backoff = Backoff.new(min_interval: 100, max_interval: 300)
+    assert %{value: ^min} = backoff = Backoff.next(backoff)
+    backoff = Backoff.next(backoff)
+    assert %{value: ^max} = backoff = Backoff.next(backoff)
+    # should roll back to min interval now
+    assert %{value: ^min} = Backoff.next(backoff)
+  end
+
+  test "should not exceed timeout value" do
+    backoff = Backoff.new(timeout: 300, min_interval: 100)
+    assert backoff = Backoff.next(backoff)
+    assert backoff = Backoff.next(backoff)
+    assert {:error, :timeout} = Backoff.next(backoff)
+  end
+
+  test "reset" do
+    backoff = Backoff.new(min_interval: 10)
+    assert backoff = snapshot = Backoff.next(backoff)
+    assert backoff = Backoff.next(backoff)
+    assert %Backoff{} = backoff = Backoff.reset(backoff)
+    assert ^snapshot = Backoff.next(backoff)
+  end
+end


### PR DESCRIPTION
This pull-request aim to improve situations where the client cannot get a connection to the broker—as #46 highlight: there is no retry when the client fail its initial connect.

The solution to this is to implement an incremental backoff, and retry the connection in the case the network should become available, the configuration on the broker should change, or something third that will allow us to make the connection.

I consider making some "blame management" on the connection failure reason. There could be situations where it would never be able to reconnect. Perhaps I should consider just killing the connection if the broker refute it, the password/user is unknown, etc.

If applied this should take care of:

  - Fix #44 Implement incremental backoff when trying to reconnect to broker
  - Fix #46 no retry on initial connection