### PR TITLE
Handle a rebooting broker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.4.1 - 2018-07-08
+
+### Changed
+
+- Tortoise should now survive the server it is connected to being
+  restarted. `{:error, :econnrefused}` and `{:error, :closed}` has
+  been added to the errors that make tortoise attempt a reconnect.
+
 ## 0.4.0 - 2018-07-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:tortoise, "~> 0.4.0"}
+    {:tortoise, "~> 0.4.1"}
   ]
 end
 ```

--- a/lib/tortoise/connection.ex
+++ b/lib/tortoise/connection.ex
@@ -388,6 +388,9 @@ defmodule Tortoise.Connection do
 
       {:error, {:options, {:cacertfile, []}}} ->
         {:error, :no_cacartfile_specified}
+
+      {:error, :closed} ->
+        {:error, :server_closed_connection}
     end
   end
 
@@ -410,6 +413,14 @@ defmodule Tortoise.Connection do
   end
 
   defp categorize_error({:nxdomain, _host, _port}) do
+    :connectivity
+  end
+
+  defp categorize_error({:connection_refused, _host, _port}) do
+    :connectivity
+  end
+
+  defp categorize_error(:server_closed_connection) do
     :connectivity
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Tortoise.MixProject do
   use Mix.Project
 
-  @version "0.4.0"
+  @version "0.4.1"
 
   def project do
     [


### PR DESCRIPTION
This implement the behavior observed from a client connected to a VerneMQ server that is being rebooted.

First it will close the connection, then it will reply with `{:error, :econnrefused}` a couple of times; and then it will finally accept connections again.