### PR TITLE
Make sure the invalid header length is anything above 5 bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.5.1 - 2018-07-23
+
+### Fixed
+
+- The receiver could report an invalid header length protocol
+  violation when the server send too few bytes, and thus taking too
+  long sending the complete package header. This patch will ensure we
+  only report invalid header length when we have pulled more than 40
+  bits in.
+
 ## 0.5.0 - 2018-07-18
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:tortoise, "~> 0.5.0"}
+    {:tortoise, "~> 0.5.1"}
   ]
 end
 ```

--- a/lib/tortoise/connection/receiver.ex
+++ b/lib/tortoise/connection/receiver.ex
@@ -188,7 +188,7 @@ defmodule Tortoise.Connection.Receiver do
     {:ok, length + 5}
   end
 
-  defp parse_fixed_header(<<_::8, _::binary>>) do
+  defp parse_fixed_header(header) when byte_size(header) > 5 do
     {:error, :invalid_header_length}
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Tortoise.MixProject do
   use Mix.Project
 
-  @version "0.5.0"
+  @version "0.5.1"
 
   def project do
     [

--- a/test/tortoise/connection/receiver_test.exs
+++ b/test/tortoise/connection/receiver_test.exs
@@ -13,10 +13,10 @@ defmodule Tortoise.Connection.ReceiverTest do
   def setup_receiver(context) do
     opts = [client_id: context.client_id]
     {:ok, client_socket, server_socket} = Tortoise.Integration.TestTCPTunnel.new()
-    {:ok, _pid} = Receiver.start_link(opts)
+    {:ok, receiver_pid} = Receiver.start_link(opts)
     {:ok, _pid} = Transmitter.start_link(opts)
     :ok = Receiver.handle_socket(context.client_id, {Tortoise.Transport.Tcp, client_socket})
-    {:ok, %{client: client_socket, server: server_socket}}
+    {:ok, %{receiver_pid: receiver_pid, client: client_socket, server: server_socket}}
   end
 
   def setup_controller(context) do
@@ -52,6 +52,32 @@ defmodule Tortoise.Connection.ReceiverTest do
 
       assert_receive {:"$gen_cast", {:incoming, data}}, 10000
       assert ^package = Package.decode(data)
+    end
+
+    test "very slow connection", context do
+      Process.flag(:trap_exit, true)
+      receiver_pid = context.receiver_pid
+      # Send a byte, one at a time, into the receiver. This has been
+      # observed in the wild and it caused a faulty pattern match to
+      # report it as an invalid_header_length protocol violation
+      :ok = :gen_tcp.send(context.server, <<0b11010000>>)
+      refute_receive {:EXIT, ^receiver_pid, {:protocol_violation, :invalid_header_length}}, 400
+      :ok = :gen_tcp.send(context.server, <<0>>)
+      assert_receive {:"$gen_cast", {:incoming, data}}, 10000
+      assert %Package.Pingresp{} = Package.decode(data)
+    end
+  end
+
+  describe "invalid packages" do
+    setup [:setup_receiver]
+
+    test "invalid header length", context do
+      Process.flag(:trap_exit, true)
+      receiver_pid = context.receiver_pid
+      # send too many bytes into the receiver, the header parser
+      # should throw a protocol violation on this
+      :ok = :gen_tcp.send(context.server, <<1, 255, 255, 255, 255, 0>>)
+      assert_receive {:EXIT, ^receiver_pid, {:protocol_violation, :invalid_header_length}}
     end
   end
 end


### PR DESCRIPTION
An error has been reported where Tortoise could report a protocol violation because of an invalid header length when receiving data from a slow connection. When digging into this issue it seems the be caused by the fixed_header parser in the receiver module that had a pattern match that would report a faulty header length when it received a partial header. The problem occurred because the MQTT broker in question send one byte at a time.

This PR will ensure we only report a invalid header length when we receive more than 40 bits of header information, and haven't found a header yet.