### PR TITLE
Error when the server send unexpected messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- The controller will stop with an `{:protocol_violation,
+  {:unexpected_package_from_remote, package}}` if the server send a
+  package of the type `package`. This is the right thing to do because
+  servers should implement the protocol proper, and clients should not
+  accept unexpected packages.
+
 ## 0.6.0 - 2018-07-29
 
 ### Changed

--- a/lib/tortoise/connection/controller.ex
+++ b/lib/tortoise/connection/controller.ex
@@ -276,9 +276,9 @@ defmodule Tortoise.Connection.Controller do
 
   # SUBSCRIBING ========================================================
   # command ------------------------------------------------------------
-  defp handle_package(%Subscribe{}, state) do
+  defp handle_package(%Subscribe{} = subscribe, state) do
     # not a server! (yet)
-    {:noreply, state}
+    {:stop, {:protocol_violation, {:unexpected_package_from_remote, subscribe}}, state}
   end
 
   # response -----------------------------------------------------------
@@ -289,9 +289,9 @@ defmodule Tortoise.Connection.Controller do
 
   # UNSUBSCRIBING ======================================================
   # command ------------------------------------------------------------
-  defp handle_package(%Unsubscribe{}, state) do
+  defp handle_package(%Unsubscribe{} = unsubscribe, state) do
     # not a server
-    {:noreply, state}
+    {:stop, {:protocol_violation, {:unexpected_package_from_remote, unsubscribe}}, state}
   end
 
   # response -----------------------------------------------------------
@@ -315,28 +315,29 @@ defmodule Tortoise.Connection.Controller do
   end
 
   # response -----------------------------------------------------------
-  defp handle_package(%Pingreq{}, state) do
+  defp handle_package(%Pingreq{} = pingreq, state) do
     # not a server!
-    {:stop, {:protocol_violation, :ping_request_from_server}, state}
+    {:stop, {:protocol_violation, {:unexpected_package_from_remote, pingreq}}, state}
   end
 
   # CONNECTING =========================================================
   # command ------------------------------------------------------------
-  defp handle_package(%Connect{}, state) do
+  defp handle_package(%Connect{} = connect, state) do
     # not a server!
-    {:noreply, state}
+    {:stop, {:protocol_violation, {:unexpected_package_from_remote, connect}}, state}
   end
 
   # response -----------------------------------------------------------
-  defp handle_package(%Connack{} = _connack, state) do
+  defp handle_package(%Connack{} = connack, state) do
     # receiving a connack at this point would be a protocol violation
-    {:noreply, state}
+    {:stop, {:protocol_violation, {:unexpected_package_from_remote, connack}}, state}
   end
 
   # DISCONNECTING ======================================================
   # command ------------------------------------------------------------
-  defp handle_package(%Disconnect{}, state) do
-    # not a server
-    {:noreply, state}
+  defp handle_package(%Disconnect{} = disconnect, state) do
+    # This should be allowed when we implement MQTT 5. Remember there
+    # is a test that assert this as a protocol violation!
+    {:stop, {:protocol_violation, {:unexpected_package_from_remote, disconnect}}, state}
   end
 end


### PR DESCRIPTION
If an unexpected message is received from the server the controller will stop with the reason `{:protocol_violation, {:unexpected_package_from_remote, package}}` where package is the unexpected package. The implementer can then log it or do whatever.