### PR TITLE
Expose connection status changes through the Tortoise.Events pubsub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@
   not dispatched using a the ETS based PubSub. This will allow the
   user to log, or do whatever they want with the ping response time.
 
+- Expose connection status changes via the `Tortoise.Events` pubsub
+  making it possible to implement custom behavior when the connection
+  goes down and when it becomes available. Great for setting up
+  alarms.
+
 ## 0.6.0 - 2018-07-29
 
 ### Changed

--- a/lib/tortoise/events.ex
+++ b/lib/tortoise/events.ex
@@ -9,7 +9,7 @@ defmodule Tortoise.Events do
   `Tortoise.Events.unregister/2` for how to unsubscribe.
   """
 
-  @types [:connection, :ping_response]
+  @types [:connection, :status, :ping_response]
 
   @doc """
   Subscribe to messages on the client with the client id `client_id`
@@ -25,6 +25,10 @@ defmodule Tortoise.Events do
   multiple clients. The value depends on the message type.
 
   Possible message types are:
+
+    - `:status` dispatched when the connection of a client changes
+      status. The value will be `:up` when the client goes online, and
+      `:down` when it goes offline.
 
     - `:ping_response` dispatched when the connection receive a
       response from a keep alive message. The value is the round trip

--- a/test/tortoise/connection/controller_test.exs
+++ b/test/tortoise/connection/controller_test.exs
@@ -133,13 +133,13 @@ defmodule Tortoise.Connection.ControllerTest do
 
     test "Callback is triggered on connection status change", context do
       # tell the controller that we are up
-      :ok = Controller.update_connection_status(context.client_id, :up)
+      :ok = Tortoise.Events.dispatch(context.client_id, :status, :up)
       assert_receive(%TestHandler{status: :up})
       # switch to offline
-      :ok = Controller.update_connection_status(context.client_id, :down)
+      :ok = Tortoise.Events.dispatch(context.client_id, :status, :down)
       assert_receive(%TestHandler{status: :down})
       # ... and back up
-      :ok = Controller.update_connection_status(context.client_id, :up)
+      :ok = Tortoise.Events.dispatch(context.client_id, :status, :up)
       assert_receive(%TestHandler{status: :up})
     end
   end


### PR DESCRIPTION
Allow processes to listen in on `:status` and get a message when the connection status changes. When registered for status-messages a process will receive a message of the form: 

  - `{{Tortoise, client_id}, :status, :up}` when the client has a connection to the broker
  - `{{Tortoise, client_id}, :status, :down}` when it drop the connection.

A process can register this status message via the `Tortoise.Events` pubsub like this `Tortoise.Events.register(client_id, :status)`.