### PR TITLE
Use the pubsub to communicate when the receiver drop the connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,17 @@
   goes down and when it becomes available. Great for setting up
   alarms.
 
+- The receiver will now broadcast a "status down" message on the
+  `Tortoise.Events` pubsub, and the connection process will listen for
+  that message and enter the reconnect on status change.
+
+### Removed
+
+- `Tortoise.Connection.reconnect/1` has been removed as it is has been
+  replaced with the pubsub based status-down message approach
+  described in the "changed"-section. It might make a return at some
+  point, but for now it has been removed.
+
 ## 0.6.0 - 2018-07-29
 
 ### Changed

--- a/test/tortoise/connection/controller_test.exs
+++ b/test/tortoise/connection/controller_test.exs
@@ -517,6 +517,7 @@ defmodule Tortoise.Connection.ControllerTest do
 
       assert capture_log(fn ->
                send(context.controller_pid, {{Tortoise, client_id}, ref, :ok})
+               :timer.sleep(100)
              end) =~ "Unexpected"
 
       %{awaiting: awaiting} = Controller.info(client_id)


### PR DESCRIPTION
By dispatching that the status is down via the pubsub, the receiver can inform the connection that it should reconnect; also we can eventually have the inflight process roll back its state and resend the messages when it has a connection.