### PR TITLE
Coerce the host given to the SSL transport to a charlist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
   messages caused by retransmisions should get trapped and not
   forwarded to the user defined publish handler.
 
+- It is now possible to pass in a binary/string as the host for a
+  connection using the `Tortoise.Transport.SSL` module; it will be
+  coerced to a charlist.
+
 ### Added
 
 - The documentation on how to connect to a broker using the

--- a/lib/tortoise/transport/ssl.ex
+++ b/lib/tortoise/transport/ssl.ex
@@ -11,9 +11,18 @@ defmodule Tortoise.Transport.SSL do
   def new(opts) do
     {host, opts} = Keyword.pop(opts, :host)
     {port, opts} = Keyword.pop(opts, :port)
+    host = coerce_host(host)
     opts = Keyword.merge(@default_opts, opts)
     opts = [:binary, {:packet, :raw}, {:active, false} | opts]
     %Transport{type: __MODULE__, host: host, port: port, opts: opts}
+  end
+
+  defp coerce_host(host) when is_binary(host) do
+    String.to_charlist(host)
+  end
+
+  defp coerce_host(otherwise) do
+    otherwise
   end
 
   @impl true


### PR DESCRIPTION
This will allow the user to pass in a binary as the host name, in which case it will get coerced into a charlist.

Fixes #66