### PR TITLE
Make the project pass dialyzer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- Upgraded to a more recent version of dialyxir and made the project
+  pass the dialyzer.
+
 ## 0.8.2 - 2018-08-26
 
 ### Fixed

--- a/lib/tortoise/package/disconnect.ex
+++ b/lib/tortoise/package/disconnect.ex
@@ -10,7 +10,7 @@ defmodule Tortoise.Package.Disconnect do
           }
   defstruct __META__: %Package.Meta{opcode: @opcode, flags: 0}
 
-  @spec decode(binary()) :: t
+  @spec decode(<<_::16>>) :: __MODULE__.t()
   def decode(<<@opcode::4, 0::4, 0>>), do: %__MODULE__{}
 
   # Protocols ----------------------------------------------------------

--- a/lib/tortoise/package/pingreq.ex
+++ b/lib/tortoise/package/pingreq.ex
@@ -10,7 +10,7 @@ defmodule Tortoise.Package.Pingreq do
           }
   defstruct __META__: %Package.Meta{opcode: @opcode, flags: 0}
 
-  @spec decode(binary()) :: t
+  @spec decode(<<_::16>>) :: __MODULE__.t()
   def decode(<<@opcode::4, 0::4, 0>>) do
     %__MODULE__{}
   end

--- a/lib/tortoise/package/pingresp.ex
+++ b/lib/tortoise/package/pingresp.ex
@@ -10,7 +10,7 @@ defmodule Tortoise.Package.Pingresp do
           }
   defstruct __META__: %Package.Meta{opcode: @opcode, flags: 0}
 
-  @spec decode(binary()) :: t
+  @spec decode(<<_::16>>) :: __MODULE__.t()
   def decode(<<@opcode::4, 0::4, 0>>) do
     %__MODULE__{}
   end

--- a/lib/tortoise/package/puback.ex
+++ b/lib/tortoise/package/puback.ex
@@ -15,7 +15,7 @@ defmodule Tortoise.Package.Puback do
   defstruct __META__: %Package.Meta{opcode: @opcode, flags: 0b0000},
             identifier: nil
 
-  @spec decode(binary()) :: t
+  @spec decode(<<_::32>>) :: __MODULE__.t()
   def decode(<<@opcode::4, 0::4, 2, identifier::big-integer-size(16)>>)
       when identifier in 0x0001..0xFFFF do
     %__MODULE__{identifier: identifier}

--- a/lib/tortoise/package/pubcomp.ex
+++ b/lib/tortoise/package/pubcomp.ex
@@ -14,7 +14,7 @@ defmodule Tortoise.Package.Pubcomp do
   defstruct __META__: %Package.Meta{opcode: @opcode, flags: 0},
             identifier: nil
 
-  @spec decode(binary()) :: t
+  @spec decode(<<_::32>>) :: __MODULE__.t()
   def decode(<<@opcode::4, 0::4, 2, identifier::big-integer-size(16)>>)
       when identifier in 0x0001..0xFFFF do
     %__MODULE__{identifier: identifier}

--- a/lib/tortoise/package/pubrec.ex
+++ b/lib/tortoise/package/pubrec.ex
@@ -14,7 +14,7 @@ defmodule Tortoise.Package.Pubrec do
   defstruct __META__: %Package.Meta{opcode: @opcode, flags: 0b000},
             identifier: nil
 
-  @spec decode(binary()) :: t
+  @spec decode(<<_::32>>) :: __MODULE__.t()
   def decode(<<@opcode::4, 0::4, 2, identifier::big-integer-size(16)>>)
       when identifier in 0x0001..0xFFFF do
     %__MODULE__{identifier: identifier}

--- a/lib/tortoise/package/pubrel.ex
+++ b/lib/tortoise/package/pubrel.ex
@@ -15,7 +15,7 @@ defmodule Tortoise.Package.Pubrel do
   defstruct __META__: %Package.Meta{opcode: @opcode, flags: 0b0010},
             identifier: nil
 
-  @spec decode(binary()) :: t
+  @spec decode(<<_::32>>) :: __MODULE__.t()
   def decode(<<@opcode::4, 2::4, 2, identifier::big-integer-size(16)>>)
       when identifier in 0x0001..0xFFFF do
     %__MODULE__{identifier: identifier}

--- a/lib/tortoise/package/unsuback.ex
+++ b/lib/tortoise/package/unsuback.ex
@@ -15,7 +15,7 @@ defmodule Tortoise.Package.Unsuback do
   defstruct __META__: %Package.Meta{opcode: @opcode, flags: 0b0000},
             identifier: nil
 
-  @spec decode(binary()) :: t
+  @spec decode(<<_::32>>) :: __MODULE__.t()
   def decode(<<@opcode::4, 0::4, 2, identifier::big-integer-size(16)>>)
       when identifier in 0x0001..0xFFFF do
     %__MODULE__{identifier: identifier}

--- a/lib/tortoise/registry.ex
+++ b/lib/tortoise/registry.ex
@@ -3,6 +3,7 @@ defmodule Tortoise.Registry do
 
   @type client_id :: term()
   @type via :: {:via, Registry, {__MODULE__, {module(), client_id()}}}
+  @type key :: atom() | tuple()
 
   @spec via_name(module(), client_id()) :: via() | pid()
   def via_name(_module, pid) when is_pid(pid), do: pid
@@ -16,12 +17,12 @@ defmodule Tortoise.Registry do
     {__MODULE__, {module, client_id}}
   end
 
-  @spec meta(key :: term()) :: :ok
+  @spec meta(key :: key()) :: {:ok, term()} | :error
   def meta(key) do
     Registry.meta(__MODULE__, key)
   end
 
-  @spec put_meta(key :: term(), value :: term()) :: :ok
+  @spec put_meta(key :: key(), value :: term()) :: :ok
   def put_meta(key, value) do
     :ok = Registry.put_meta(__MODULE__, key, value)
   end

--- a/mix.exs
+++ b/mix.exs
@@ -45,7 +45,7 @@ defmodule Tortoise.MixProject do
     [
       {:gen_state_machine, "~> 2.0"},
       {:eqc_ex, "~> 1.4"},
-      {:dialyxir, "~> 0.5", only: [:dev, :test], runtime: false},
+      {:dialyxir, "~> 1.0.0-rc.3", only: [:dev], runtime: false},
       {:excoveralls, "~> 0.10", only: :test},
       {:ex_doc, "~> 0.19", only: :docs},
       {:ct_helper, github: "ninenines/ct_helper", only: :test}
@@ -79,7 +79,8 @@ defmodule Tortoise.MixProject do
 
   defp dialyzer() do
     [
-      ignore_warnings: "dialyzer.ignore"
+      ignore_warnings: "dialyzer.ignore",
+      flags: [:error_handling, :race_conditions, :underspecs]
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,7 +1,7 @@
 %{
   "certifi": {:hex, :certifi, "2.3.1", "d0f424232390bf47d82da8478022301c561cf6445b5b5fb6a84d49a9e76d2639", [:rebar3], [{:parse_trans, "3.2.0", [hex: :parse_trans, repo: "hexpm", optional: false]}], "hexpm"},
   "ct_helper": {:git, "https://github.com/ninenines/ct_helper.git", "6cf0748b5ac7bd32f8d338224b843e419b1ea7c0", []},
-  "dialyxir": {:hex, :dialyxir, "0.5.1", "b331b091720fd93e878137add264bac4f644e1ddae07a70bf7062c7862c4b952", [:mix], [], "hexpm"},
+  "dialyxir": {:hex, :dialyxir, "1.0.0-rc.3", "774306f84973fc3f1e2e8743eeaa5f5d29b117f3916e5de74c075c02f1b8ef55", [:mix], [], "hexpm"},
   "earmark": {:hex, :earmark, "1.2.5", "4d21980d5d2862a2e13ec3c49ad9ad783ffc7ca5769cf6ff891a4553fbaae761", [:mix], [], "hexpm"},
   "eqc_ex": {:hex, :eqc_ex, "1.4.2", "c89322cf8fbd4f9ddcb18141fb162a871afd357c55c8c0198441ce95ffe2e105", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.19.1", "519bb9c19526ca51d326c060cb1778d4a9056b190086a8c6c115828eaccea6cf", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.7", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},


### PR DESCRIPTION
I've upgraded to the latest (release candidate) release of dialixer—and I have added the following to the configuration `flags: [:error_handling, :race_conditions, :underspecs]`

The current warnings has been taken care of.