### PR TITLE
Create a macro for building `Tortoise.Handler`

### DIFF
--- a/lib/tortoise/handler.ex
+++ b/lib/tortoise/handler.ex
@@ -118,6 +118,39 @@ defmodule Tortoise.Handler do
           {:subscribe, topic_filter(), [topic_opts()]}
           | {:unsubscribe, topic_filter()}
 
+  defmacro __using__(_opts) do
+    quote location: :keep do
+      @behaviour Tortoise.Handler
+
+      @impl true
+      def init(state) do
+        {:ok, state}
+      end
+
+      @impl true
+      def terminate(_reason, _state) do
+        :ok
+      end
+
+      @impl true
+      def connection(_status, state) do
+        {:ok, state}
+      end
+
+      @impl true
+      def subscription(_status, _topic_filter, state) do
+        {:ok, state}
+      end
+
+      @impl true
+      def handle_message(_topic, _payload, state) do
+        {:ok, state}
+      end
+
+      defoverridable Tortoise.Handler
+    end
+  end
+
   @doc """
   Invoked when the connection is started.
 

--- a/lib/tortoise/handler/default.ex
+++ b/lib/tortoise/handler/default.ex
@@ -1,33 +1,5 @@
 defmodule Tortoise.Handler.Default do
   @moduledoc false
 
-  @behaviour Tortoise.Handler
-
-  defstruct []
-  alias __MODULE__, as: State
-
-  @impl true
-  def init(_opts) do
-    {:ok, %State{}}
-  end
-
-  @impl true
-  def connection(_status, state) do
-    {:ok, state}
-  end
-
-  @impl true
-  def subscription(_status, _topic, state) do
-    {:ok, state}
-  end
-
-  @impl true
-  def handle_message(_topic, _publish, state) do
-    {:ok, state}
-  end
-
-  @impl true
-  def terminate(_reason, _state) do
-    :ok
-  end
+  use Tortoise.Handler
 end


### PR DESCRIPTION
Make it possible to `use Tortoise.Handler` in a module, which will bring in default implementation for the user defined handler callbacks.

This should improve the usability of the project quite a bit.

When applied this will Fix #52 