### PR TITLE
v0.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## [Unreleased]
+
 ## 0.9.1 - 2018-08-31
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
-## [Unreleased]
+## 0.9.2 - 2018-09-01
+
+### Added
+
+- A use-macro has been added to `Tortoise.Handler` which implements
+  default behaviour for the callbacks so the user only have to
+  implement the callbacks they care about. This should improve
+  usability of the project quite a bit.
 
 ## 0.9.1 - 2018-08-31
 

--- a/README.md
+++ b/README.md
@@ -73,15 +73,15 @@ Look at the `connection_test.exs`-file for more examples.
 
 Example Handler
 ```elixir
-defmodule Tortoise.Handler.Logger do
-  @behaviour Tortoise.Handler
+defmodule Tortoise.Handler.Example do
+  use Tortoise.Handler
 
   def init(args) do
     {:ok, args}
   end
 
   def connection(status, state) do
-    # `status` would be either `:up` or `:down`; you can use this to
+    # `status` will be either `:up` or `:down`; you can use this to
     # inform the rest of your system if the connection is currently
     # open or closed; tortoise should be busy reconnecting if you get
     # a `:down`

--- a/lib/tortoise/handler/default.ex
+++ b/lib/tortoise/handler/default.ex
@@ -1,33 +1,5 @@
 defmodule Tortoise.Handler.Default do
   @moduledoc false
 
-  @behaviour Tortoise.Handler
-
-  defstruct []
-  alias __MODULE__, as: State
-
-  @impl true
-  def init(_opts) do
-    {:ok, %State{}}
-  end
-
-  @impl true
-  def connection(_status, state) do
-    {:ok, state}
-  end
-
-  @impl true
-  def subscription(_status, _topic, state) do
-    {:ok, state}
-  end
-
-  @impl true
-  def handle_message(_topic, _publish, state) do
-    {:ok, state}
-  end
-
-  @impl true
-  def terminate(_reason, _state) do
-    :ok
-  end
+  use Tortoise.Handler
 end

--- a/lib/tortoise/handler/logger.ex
+++ b/lib/tortoise/handler/logger.ex
@@ -3,17 +3,16 @@ defmodule Tortoise.Handler.Logger do
 
   require Logger
 
+  use Tortoise.Handler
+
   defstruct []
   alias __MODULE__, as: State
 
-  @behaviour Tortoise.Handler
-
-  @impl true
   def init(_opts) do
+    Logger.info("Initializing handler")
     {:ok, %State{}}
   end
 
-  @impl true
   def connection(:up, state) do
     Logger.info("Connection has been established")
     {:ok, state}
@@ -29,7 +28,6 @@ defmodule Tortoise.Handler.Logger do
     {:ok, state}
   end
 
-  @impl true
   def subscription(:up, topic, state) do
     Logger.info("Subscribed to #{topic}")
     {:ok, state}
@@ -50,13 +48,11 @@ defmodule Tortoise.Handler.Logger do
     {:ok, state}
   end
 
-  @impl true
   def handle_message(topic, publish, state) do
     Logger.info("#{Enum.join(topic, "/")} #{inspect(publish)}")
     {:ok, state}
   end
 
-  @impl true
   def terminate(reason, _state) do
     Logger.warn("Client has been terminated with reason: #{inspect(reason)}")
     :ok

--- a/lib/tortoise/package/publish.ex
+++ b/lib/tortoise/package/publish.ex
@@ -5,15 +5,15 @@ defmodule Tortoise.Package.Publish do
 
   alias Tortoise.Package
 
-  @opaque t :: %__MODULE__{
-            __META__: Package.Meta.t(),
-            topic: Tortoise.topic() | nil,
-            qos: Tortoise.qos(),
-            payload: Tortoise.payload(),
-            identifier: Tortoise.package_identifier(),
-            dup: boolean(),
-            retain: boolean()
-          }
+  @type t :: %__MODULE__{
+          __META__: Package.Meta.t(),
+          topic: Tortoise.topic() | nil,
+          qos: Tortoise.qos(),
+          payload: Tortoise.payload(),
+          identifier: Tortoise.package_identifier(),
+          dup: boolean(),
+          retain: boolean()
+        }
   defstruct __META__: %Package.Meta{opcode: @opcode, flags: 0},
             identifier: nil,
             topic: nil,

--- a/test/tortoise/connection/controller_test.exs
+++ b/test/tortoise/connection/controller_test.exs
@@ -8,7 +8,7 @@ defmodule Tortoise.Connection.ControllerTest do
   import ExUnit.CaptureLog
 
   defmodule TestHandler do
-    @behaviour Tortoise.Handler
+    use Tortoise.Handler
 
     defstruct pid: nil,
               client_id: nil,


### PR DESCRIPTION
In this release a use-macro for `Tortoise.Handler` has been added. This should make it easier to implement custom handler modules as the implementor only have to implement the callbacks that are interesting for their use-case.

Fix #52 