### PR TITLE
 Make "eqc_ex" dependency only available in test

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,16 @@ end
 Documentation should be available at
 [https://hexdocs.pm/tortoise](https://hexdocs.pm/tortoise).
 
+## Development
+
+To start developing, run the following commands:
+
+```
+mix deps.get
+MIX_ENV=test mix eqc.install --mini
+mix test
+```
+
 ## Building documentation
 
 To build the documentation run the following command in a terminal emulator:

--- a/mix.exs
+++ b/mix.exs
@@ -44,8 +44,8 @@ defmodule Tortoise.MixProject do
   defp deps do
     [
       {:gen_state_machine, "~> 2.0"},
-      {:eqc_ex, "~> 1.4"},
       {:dialyxir, "~> 1.0.0-rc.3", only: [:dev], runtime: false},
+      {:eqc_ex, "~> 1.4", only: :test},
       {:excoveralls, "~> 0.10", only: :test},
       {:ex_doc, "~> 0.19", only: :docs},
       {:ct_helper, github: "ninenines/ct_helper", only: :test}


### PR DESCRIPTION
Since QuickCheck is only used in "test" environment, would you consider restricting `eqc_ex` in the environment only?