### PR TITLE
Catch other connection errors

### DIFF
--- a/lib/tortoise/connection.ex
+++ b/lib/tortoise/connection.ex
@@ -608,6 +608,9 @@ defmodule Tortoise.Connection do
 
       {:error, :closed} ->
         {:error, :server_closed_connection}
+
+      {:error, other} ->
+        {:error, other}
     end
   end
 


### PR DESCRIPTION
I was receiving TLS certificate unknown alerts from the server. They were handled differently from other connection errors. I wasn't completely sure if you wanted to handle errors on a case-by-case basis to see if they could benefit from more information or not. The only other error that I've seen so far is `{:error, {:tls_alert, something}}` if that's the case.