### PR TITLE
Add server option to Connection.start_link/1 spec

### DIFF
--- a/lib/tortoise/connection.ex
+++ b/lib/tortoise/connection.ex
@@ -25,6 +25,7 @@ defmodule Tortoise.Connection do
   @spec start_link(options, GenServer.options()) :: GenServer.on_start()
         when option:
                {:client_id, Tortoise.client_id()}
+               | {:server, {atom(), term()}}
                | {:user_name, String.t()}
                | {:password, String.t()}
                | {:keep_alive, non_neg_integer()}


### PR DESCRIPTION
Dialyzer was giving errors when calling the function and passing the
server option