### PR TITLE
Classify :enetunreach as connectivity error

### DIFF
--- a/lib/tortoise/connection.ex
+++ b/lib/tortoise/connection.ex
@@ -655,6 +655,10 @@ defmodule Tortoise.Connection do
     :connectivity
   end
 
+  defp categorize_error(:enetunreach) do
+    :connectivity
+  end
+
   defp categorize_error(_other) do
     :other
   end


### PR DESCRIPTION
This is similar to what done in #94, and is necessary so that `Tortoise.Connection` will attempt a reconnection instead of terminating when the network is temporarily unreachable.

In my IoT project, if I unplug the ethernet cable, the following happens:

  1. Upon the next keepalive ping, the `Tortoise.Connection` GenServer terminates due to `:ping_timeout`. Ideally, this would not cause the server to terminate, but rather to attempt a re-connection (as suggested in #116), but this is not the focus of this PR.

  2. As the `Tortoise.Connection` GenServer is restarted by its supervisor, it quickly and repeatedly crashes when trying to connect due to `{:error, :enetunreach}`, and eventually the supervisor stops trying to restart it and the whole application terminates.

This PR classifies such error as a connectivity problem, and triggers the backoff reconnection logic instead.

Note: it is possible that other errors defined in http://erlang.org/doc/man/inet.html#type-posix might occur too in some cases (like `:enetdown`), even though I only experienced `:enetunreach` in my case.