### PR TITLE
Misc module doc changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,12 +162,12 @@ mix test
 To build the documentation run the following command in a terminal emulator:
 
 ``` shell
-MIX_ENV=docs mix docs
+mix docs
 ```
 
 This will build the documentation in place them in the *doc*-folder in
 the root of the project. These docs will also find their way to the
-Hexdocs website when the project is published on Hex.
+HexDocs website when the project is published on Hex.
 
 ## License
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,13 +1,14 @@
 defmodule Tortoise.MixProject do
   use Mix.Project
 
-  @version "0.10.0"
+  @source_url "https://github.com/gausby/tortoise"
+  @version "0.9.5"
 
   def project do
     [
       app: :tortoise,
       version: @version,
-      elixir: "~> 1.6",
+      elixir: "~> 1.7",
       start_permanent: Mix.env() == :prod,
       description: description(),
       package: package(),
@@ -20,8 +21,7 @@ defmodule Tortoise.MixProject do
         "coveralls.detail": :test,
         "coveralls.html": :test,
         "coveralls.json": :test,
-        "coveralls.post": :test,
-        docs: :docs
+        "coveralls.post": :test
       ]
     ]
   end
@@ -32,7 +32,6 @@ defmodule Tortoise.MixProject do
     """
   end
 
-  # Run "mix help compile.app" to learn about applications.
   def application do
     [
       extra_applications: [:logger, :ssl],
@@ -40,7 +39,6 @@ defmodule Tortoise.MixProject do
     ]
   end
 
-  # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
       {:gen_state_machine, "~> 2.0 or ~> 3.0"},
@@ -57,7 +55,7 @@ defmodule Tortoise.MixProject do
       maintainers: ["Martin Gausby"],
       licenses: ["Apache 2.0"],
       files: ["lib", "mix.exs", "README*", "CHANGELOG*", "LICENSE*"],
-      links: %{"GitHub" => "https://github.com/gausby/tortoise"}
+      links: %{"Changelog" => "#{@source_url}/blob/master/CHANGELOG.md", "GitHub" => @source_url}
     ]
   end
 
@@ -67,7 +65,7 @@ defmodule Tortoise.MixProject do
       source_ref: "v#{@version}",
       main: "introduction",
       canonical: "http://hexdocs.pm/tortoise",
-      source_url: "https://github.com/gausby/tortoise",
+      source_url: @source_url,
       extras: [
         "docs/introduction.md",
         "docs/connecting_to_a_mqtt_broker.md",


### PR DESCRIPTION
List of changes:
- Ensure doc generation in dev env
- Use common source url
- Add changelog link to hex module info
- Bump Elixir to 1.7 for ex_doc 1.9 requirement
- Remove comments
- Fix typo