### PR TITLE
Support passing options to Transport constructors

### DIFF
--- a/lib/tortoise/transport/ssl.ex
+++ b/lib/tortoise/transport/ssl.ex
@@ -11,9 +11,10 @@ defmodule Tortoise.Transport.SSL do
   def new(opts) do
     {host, opts} = Keyword.pop(opts, :host)
     {port, opts} = Keyword.pop(opts, :port)
+    {list_opts, opts} = Keyword.pop(opts, :opts, [])
     host = coerce_host(host)
     opts = Keyword.merge(@default_opts, opts)
-    opts = [:binary, {:packet, :raw}, {:active, false} | opts]
+    opts = [:binary, {:packet, :raw}, {:active, false} | opts] ++ list_opts
     %Transport{type: __MODULE__, host: host, port: port, opts: opts}
   end
 

--- a/lib/tortoise/transport/tcp.ex
+++ b/lib/tortoise/transport/tcp.ex
@@ -9,8 +9,9 @@ defmodule Tortoise.Transport.Tcp do
   def new(opts) do
     {host, opts} = Keyword.pop(opts, :host)
     {port, opts} = Keyword.pop(opts, :port, 1883)
+    {list_opts, opts} = Keyword.pop(opts, :opts, [])
     host = coerce_host(host)
-    opts = [:binary, {:packet, :raw}, {:active, false} | opts]
+    opts = [:binary, {:packet, :raw}, {:active, false} | opts] ++ list_opts
     %Transport{type: __MODULE__, host: host, port: port, opts: opts}
   end
 


### PR DESCRIPTION
This adds support for passing through options to the underlying Transport
constructors, for example to support IPv6. Patch originally suggested by Brian
May.

Fixes #111.

Suggested-by: Brian May <brian@linuxpenguins.xyz>
Signed-off-by: Toke Høiland-Jørgensen <toke@toke.dk>