### PR TITLE
Handle connection timeout in the publish functions

### DIFF
--- a/lib/tortoise.ex
+++ b/lib/tortoise.ex
@@ -278,6 +278,9 @@ defmodule Tortoise do
     else
       {:error, :unknown_connection} ->
         {:error, :unknown_connection}
+
+      {:error, :timeout} ->
+        {:error, :timeout}
     end
   end
 
@@ -338,6 +341,9 @@ defmodule Tortoise do
     else
       {:error, :unknown_connection} ->
         {:error, :unknown_connection}
+
+      {:error, :timeout} ->
+        {:error, :timeout}
     end
   end
 end


### PR DESCRIPTION
Hey, I noticed during the tests that the connection timeout error is not handled in the lib. My stack trace below. I'd like to be able to handle it in my app's logic. 

     ** (WithClauseError) no with clause matching: {:error, :timeout}
     code: conn = ...
     stacktrace:
       (tortoise 0.9.5) lib/tortoise.ex:269: Tortoise.publish/4