### PR TITLE
Use Clean-Session from Connection Options

### DIFF
--- a/lib/tortoise/connection.ex
+++ b/lib/tortoise/connection.ex
@@ -43,6 +43,7 @@ defmodule Tortoise.Connection do
                | {:will, Tortoise.Package.Publish.t()}
                | {:subscriptions,
                   [{Tortoise.topic_filter(), Tortoise.qos()}] | Tortoise.Package.Subscribe.t()}
+               | {:clean_session, boolean()}
                | {:handler, {atom(), term()}},
              options: [option]
   def start_link(connection_opts, opts \\ []) do
@@ -56,7 +57,7 @@ defmodule Tortoise.Connection do
       keep_alive: Keyword.get(connection_opts, :keep_alive, 60),
       will: Keyword.get(connection_opts, :will),
       # if we re-spawn from here it means our state is gone
-      clean_session: true
+      clean_session: Keyword.get(connection_opts, :clean_session, true)
     }
 
     backoff = Keyword.get(connection_opts, :backoff, [])


### PR DESCRIPTION
The Option `clean_session` is already implemented, but always set to `true`.

This PR adds 2 lines to be able to set `clean_session` as `false` with `connection_options`.

Unfortunately I can't run tests with Elixir 1.10, because the QuickCheck library can't be downloaded (is fixed in eqc, but not released yet, see https://github.com/Quviq/eqc_ex/commit/1e8367293a06de050bbceffc53ac2aca7696dae7) and a further problem in eqc_ex.