### PR TITLE
Get last will message from handler on connecting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [Unreleased]
+
+- Added an optional handler callback to request a last will message from
+  the handler on each connect. If none is provided by the handler, the
+  last will message, if any, set when initializing Connection is used
+  as before.
+
 ## 0.9.9 - 2021-06-14
 
 - Switch to using `:ssl.handshake` instead of `:ssl.ssl_accept`

--- a/docs/connecting_to_a_mqtt_broker.md
+++ b/docs/connecting_to_a_mqtt_broker.md
@@ -201,10 +201,11 @@ broker if the client is abruptly disconnected from the broker. This
 message is known as the last will message, and allows for other
 connected clients to act on other clients leaving the broker.
 
-The last will message is specified as part of the connection, and for
+The (default) last will message is specified as part of the connection, and for
 Tortoise it is possible to configure a last will message by passing in
 a `Tortoise.Package.Publish` struct to the *will* connection
-configuration field.
+configuration field. Note that the Tortoise handler can provide a new last will message for 
+each new connection. If the handler chooses not to, the connection's default message will be used.
 
 ``` elixir
 {:ok, pid} =


### PR DESCRIPTION
We have a need to set a different last will message for each connection to the MQTT server. I added a handler callback to get a last will message on each connect. If none is provided by the handler, the (now default) last will message, set when init-ing the Connection genserver, is used. This is meant to be a non-breaking, backward-compatible change.