### PR TITLE
Fix type of publishable payload: it's `iodata()|nil`, not `binary()|nil`

### DIFF
--- a/lib/tortoise.ex
+++ b/lib/tortoise.ex
@@ -176,7 +176,7 @@ defmodule Tortoise do
   The payload will be `nil` if there is no payload. This is done to
   distinct between a zero byte binary and an empty payload.
   """
-  @type payload() :: binary() | nil
+  @type payload() :: iodata() | nil
 
   @doc """
   Publish a message to the MQTT broker.
@@ -248,7 +248,7 @@ defmodule Tortoise do
   """
   @spec publish(client_id(), topic(), payload, [options]) ::
           :ok | {:ok, reference()} | {:error, :unknown_connection}
-        when payload: binary() | nil,
+        when payload: payload(),
              options:
                {:qos, qos()}
                | {:retain, boolean()}
@@ -309,7 +309,7 @@ defmodule Tortoise do
   """
   @spec publish_sync(client_id(), topic(), payload, [options]) ::
           :ok | {:error, :unknown_connection}
-        when payload: binary() | nil,
+        when payload: payload(),
              options:
                {:qos, qos()}
                | {:retain, boolean()}


### PR DESCRIPTION
These get fed into
```elixir
%Package.Publish{
  topic: topic,
  qos: qos,
  payload: payload,
  retain: Keyword.get(opts, :retain, false)
}
```
then
```elixir
encoded_publish = Package.encode(publish)
```
which matches
```elixir
defmodule Tortoise.Package.Publish do
  defimpl Tortoise.Encodable do
    def encode(%Package.Publish{}) do
      [
        ...,
        Package.variable_length_encode([
          ...,
          payload
        ])
      ]
```
which already forms an iodata()

Testing confirms this result

Sponsored-by: https://beaverlabs.net