### PR TITLE
Form iolist directly instead of reallocating it in variable_length_encode()

### DIFF
--- a/lib/tortoise/package.ex
+++ b/lib/tortoise/package.ex
@@ -31,7 +31,7 @@ defmodule Tortoise.Package do
   @doc false
   def variable_length_encode(data) when is_list(data) do
     length_prefix = data |> IO.iodata_length() |> remaining_length()
-    length_prefix ++ data
+    [length_prefix, data]
   end
 
   @highbit 0b10000000


### PR DESCRIPTION
While the complexity is only proportional to `length(length_prefix)`, it could also just not have a complexity at all

Sponsored-by: https://beaverlabs.net